### PR TITLE
[⚙️ GitHub CI/CD Pipeline | Part 2] Composite actions + migrate deploy workflows

### DIFF
--- a/.github/actions/bun_install/action.yml
+++ b/.github/actions/bun_install/action.yml
@@ -1,0 +1,25 @@
+name: Bun Install
+description: >-
+  Install Bun, restore the Bun install cache, then run
+  `bun install --frozen-lockfile`. Bun version is pinned.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
+      with:
+        bun-version: 1.3.13
+
+    # Caches Bun's global download cache to skip re-downloading packages.
+    - name: Restore Bun install cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-${{ runner.arch }}-bun-store-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-bun-store-
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/actions/docker_compose_up/action.yml
+++ b/.github/actions/docker_compose_up/action.yml
@@ -1,0 +1,44 @@
+name: Docker Compose
+description: >-
+  Log in to GHCR, export the image tag/repo env vars, pull, and start a
+  Docker Compose profile against a pinned image tag.
+
+inputs:
+  profile:
+    description: Compose profile to bring up (e.g. `api`, `landing`, `web`).
+    required: true
+  tag:
+    description: Image tag to pull (e.g. the PR head SHA).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    # GHCR paths are case-sensitive and must be lowercase.
+    - name: Export environment variables
+      shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+      run: |
+        echo "TOKENOVERFLOW_IMAGE_TAG=${INPUT_TAG}" >> "$GITHUB_ENV"
+        echo "TOKENOVERFLOW_IMAGE_REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+    - name: Pull images
+      shell: bash
+      env:
+        INPUT_PROFILE: ${{ inputs.profile }}
+      run: docker compose --profile "${INPUT_PROFILE}" pull --policy always
+
+    # `--no-build` guards against silent rebuilds when a pull fails.
+    - name: Start stack
+      shell: bash
+      env:
+        INPUT_PROFILE: ${{ inputs.profile }}
+      run: docker compose --profile "${INPUT_PROFILE}" up -d --no-build --wait --wait-timeout 600

--- a/.github/actions/playwright_install/action.yml
+++ b/.github/actions/playwright_install/action.yml
@@ -1,0 +1,40 @@
+name: Playwright Install
+description: >-
+  Restore the Playwright browser cache for the given app, installing browsers
+  + OS deps only on a cache miss.
+
+inputs:
+  app:
+    description: Workspace name suffix (`landing` or `web`).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate app input
+      shell: bash
+      env:
+        INPUT_APP: ${{ inputs.app }}
+      run: |
+        case "${INPUT_APP}" in
+          landing|web) ;;
+          *) echo "Invalid app: ${INPUT_APP}" >&2; exit 1 ;;
+        esac
+
+    # Browser binaries are pinned by Playwright's version in bun.lock.
+    - name: Restore Playwright browser cache
+      id: cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ inputs.app }}-${{ hashFiles('bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-playwright-${{ inputs.app }}-
+
+    # `--with-deps` is the supported way to install OS packages Playwright needs.
+    - name: Install Playwright browsers
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        INPUT_APP: ${{ inputs.app }}
+      run: bunx "--filter=@tokenoverflow/${INPUT_APP}" playwright install --with-deps

--- a/.github/actions/rust_toolchain/action.yml
+++ b/.github/actions/rust_toolchain/action.yml
@@ -1,0 +1,34 @@
+name: Rust Toolchain
+description: >-
+  Install a pinned Rust toolchain and attach Swatinem's rust-cache. The
+  `toolchain` input feeds both dtolnay/rust-toolchain and the cache key.
+
+inputs:
+  toolchain:
+    description: Rust toolchain to install (`stable` or `nightly`).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate toolchain input
+      shell: bash
+      env:
+        INPUT_TOOLCHAIN: ${{ inputs.toolchain }}
+      run: |
+        case "${INPUT_TOOLCHAIN}" in
+          stable|nightly) ;;
+          *) echo "Invalid toolchain: ${INPUT_TOOLCHAIN}" >&2; exit 1 ;;
+        esac
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9  # stable
+      with:
+        toolchain: ${{ inputs.toolchain }}
+
+    # `shared-key` keeps the cache stable across jobs; arch + toolchain
+    # avoid cross-poisoning between stable and nightly.
+    - name: Restore Cargo + target cache
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+      with:
+        shared-key: arm64-${{ inputs.toolchain }}

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -38,7 +38,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9  # stable
+        uses: ./.github/actions/rust_toolchain
         with:
           toolchain: stable
 

--- a/.github/workflows/deploy_landing.yml
+++ b/.github/workflows/deploy_landing.yml
@@ -32,10 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: 1.3.13
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
 
       - name: Configure AWS credentials
         if: ${{ !github.event.act }}
@@ -43,9 +41,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Build landing
         run: bun run build:landing

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -33,10 +33,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
-        with:
-          bun-version: 1.3.13
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
 
       - name: Configure AWS credentials
         if: ${{ !github.event.act }}
@@ -44,9 +42,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Build BFF
         run: bun run build:web

--- a/docs/design/2026_05_24_github_ci_cd_pipeline.md
+++ b/docs/design/2026_05_24_github_ci_cd_pipeline.md
@@ -34,7 +34,9 @@ fast local feedback checks.
 - Add a reusable LHCI workflow for the landing app.
 - Align Compose profiles to e2e legs and reuse the existing `redeploy_local`
   helper to boot the full stack.
-- Upload Playwright reports, JUnit XML, and Compose logs as e2e artifacts.
+- Upload Playwright reports and JUnit XML as e2e artifacts. On e2e failure,
+  also dump container logs to stdout and upload them as an artifact with
+  3-day retention.
 - Remove the `turbo-test-e2e` pre-commit hook.
 - Update pre-commit coverage so it skips the e2e binary.
 - Keep all other pre-commit hooks, including unit and integration tests.
@@ -586,6 +588,42 @@ fast local feedback checks.
 - Cons: E2E pull contract breaks when a needed `:sha` does not exist.
 - Rationale: Rejected.
 
+### How are e2e Docker logs captured?
+
+#### ✅ Option 1: step-security/gh-docker-logs on failure, stdout + 3-day artifact
+
+- Description: `e2e_test.yml` calls
+  `step-security/gh-docker-logs` with `if: failure()`. The action dumps every
+  container's logs to stdout (visible inline in the failed job UI) and to a
+  per-leg `docker-logs-<app>` artifact uploaded with `retention-days: 3`.
+- Pros: Off-the-shelf, security-hardened fork of `jwalton/gh-docker-logs`;
+  no log noise or artifact bloat on green runs; stdout gives instant
+  in-browser visibility; 3-day retention keeps artifact storage bounded
+  while leaving enough time to triage a failed PR.
+- Cons: Flaky tests that pass on retry leave no captured logs.
+- Rationale: Matches the dominant monorepo CI pattern (caller-side capture
+  via well-known action) and aligns with the project's existing reliance on
+  pinned third-party actions.
+
+#### ❌ Option 2: Custom `docker_logs` composite uploaded `if: always()`
+
+- Description: Hand-roll a sibling composite mirroring gh-docker-logs and
+  upload on every run.
+- Pros: One less third-party dependency.
+- Cons: Reinvents an existing maintained action; artifact bloat on green
+  runs (90-day default retention multiplied by every PR).
+- Rationale: Rejected.
+
+#### ❌ Option 3: `docker_compose_up` post-step uploads `compose.log` always
+
+- Description: Original v0 intent (and the wording on the `docker_compose_up`
+  interface bullet, since corrected).
+- Pros: Single touchpoint.
+- Cons: Composite actions cannot register true post-steps. An inline capture
+  inside the composite would run before the caller's tests, missing every
+  log line that matters for e2e debugging.
+- Rationale: Rejected (technically infeasible).
+
 ## Architecture Overview
 
 ```
@@ -657,6 +695,7 @@ SHA and comment in lockstep.
 | Path-filter change detection | `dorny/paths-filter`          | Re-use SHA (`v3.0.2`).                                    |
 | Playwright browsers install  | `bunx playwright install`     | Playwright's own CLI. No marketplace action.              |
 | Artifact upload              | `actions/upload-artifact`     | Latest `v4` SHA.                                          |
+| Docker log capture           | `step-security/gh-docker-logs` | Latest `v2` SHA. Failure-only, stdout + artifact.        |
 | Trivy filesystem scan        | `aquasecurity/trivy-action`   | Latest `v0` SHA.                                          |
 | Lighthouse CI                | `bun run test:lhci`           | Uses `@lhci/cli` (devDependency).                         |
 | Markdown lint                | `bunx markdownlint-cli`       | Same binary as the pre-commit hook.                       |
@@ -727,7 +766,10 @@ apps/landing/playwright.config.ts    # modified: retries: 1
 - **`docker_compose_up`** (inputs: `profile`, `tag`): logs in to GHCR, exports
   `TOKENOVERFLOW_IMAGE_TAG`/`TOKENOVERFLOW_IMAGE_REPO`, runs
   `docker compose --profile <profile> pull --policy always` then
-  `up -d --no-build --wait --wait-timeout 600`. Post-step uploads `compose.log`.
+  `up -d --no-build --wait --wait-timeout 600`. Logs are captured by the
+  caller via `step-security/gh-docker-logs` on failure (composite actions
+  cannot register true post-steps; see Key Decision "How are e2e Docker
+  logs captured?").
 - **`playwright_install`** (inputs: `app` = `landing` | `web`): restores
   Playwright browser cache keyed on `bun.lock`, runs
   `bunx --filter=@tokenoverflow/<app> playwright install --with-deps` on miss.
@@ -792,8 +834,10 @@ corresponding profile, then runs:
 - `landing`: `bun run --filter=@tokenoverflow/landing test:e2e`.
 - `web`: `bun run --filter=@tokenoverflow/web test:e2e`.
 
-Artifacts: `apps/<app>/playwright-report/**`, `apps/<app>/test-results/**`,
-`compose.log` (always).
+Artifacts (always): `apps/<app>/playwright-report/**`,
+`apps/<app>/test-results/**`. On failure only, an additional
+`docker-logs-<app>` artifact is uploaded with `retention-days: 3`, and the
+same logs are dumped to stdout for in-UI debugging.
 
 ### Reusable workflow: `lhci.yml`
 
@@ -1187,7 +1231,8 @@ after two weeks of green data.
 - `e2e_test (api)` log shows `Pulling ghcr.io/<owner>/<repo>/api:<sha>` and
   `--no-build`.
 - `cargo test --test e2e -- --test-threads=1` passes.
-- Artifacts: `compose.log`, `playwright-report`, `test-results`.
+- Artifacts (always): `playwright-report`, `test-results`. On failure only:
+  `docker-logs-<app>` (3-day retention) + stdout dump.
 
 #### Task 8: lhci.yml
 

--- a/scripts/src/git_hooks/trivy.sh
+++ b/scripts/src/git_hooks/trivy.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# Wraps `trivy fs` to auto-skip dirs from `.gitignore`.
+# Wraps `trivy fs` to auto-skip paths from `.gitignore`.
 # Avoids maintaining a separate skip list (Trivy lacks native support).
-# Uses `git ls-files` to get ignored directories, formats them for Trivy.
-# Skips file-only entries (e.g. `.DS_Store`) since Trivy handles them.
+# Uses `git ls-files` to get ignored entries, splits into dirs and files.
 
 set -euo pipefail
 
-SKIP=$(git ls-files --others --ignored --exclude-standard --directory \
-  | awk '/\/$/ { sub(/\/$/, ""); print }' \
-  | paste -sd ',' -)
+ENTRIES=$(git ls-files --others --ignored --exclude-standard --directory)
 
-if [ -n "$SKIP" ]; then
-  exec trivy fs --disable-telemetry --exit-code 1 --severity='HIGH,CRITICAL' --skip-dirs "$SKIP" .
-else
-  exec trivy fs --disable-telemetry --exit-code 1 --severity='HIGH,CRITICAL' .
-fi
+SKIP_DIRS=$(awk '/\/$/ { sub(/\/$/, ""); print }' <<<"$ENTRIES" | paste -sd ',' -)
+SKIP_FILES=$(awk '!/\/$/' <<<"$ENTRIES" | paste -sd ',' -)
+
+ARGS=(fs --disable-telemetry --exit-code 1 --severity='HIGH,CRITICAL')
+[ -n "$SKIP_DIRS" ] && ARGS+=(--skip-dirs "$SKIP_DIRS")
+[ -n "$SKIP_FILES" ] && ARGS+=(--skip-files "$SKIP_FILES")
+
+exec trivy "${ARGS[@]}" .

--- a/scripts/tests/git_hooks/test_trivy.sh
+++ b/scripts/tests/git_hooks/test_trivy.sh
@@ -69,7 +69,7 @@ function test_joins_multiple_ignored_dirs_with_commas() {
   assert_contains "," "$output"
 }
 
-function test_ignores_file_only_gitignore_entries() {
+function test_passes_file_only_gitignore_entries_via_skip_files() {
   printf '.DS_Store\nbuild/\n' >.gitignore
   touch .DS_Store
   mkdir build
@@ -78,7 +78,7 @@ function test_ignores_file_only_gitignore_entries() {
   git commit -q -m init
   local output
   output="$("$HOOK_SCRIPT")"
-  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --skip-dirs build ." "$output"
+  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --skip-dirs build --skip-files .DS_Store ." "$output"
 }
 
 function test_handles_nested_ignored_dirs() {


### PR DESCRIPTION
## Summary

Implements **Task 2** of [docs/design/2026_05_24_github_ci_cd_pipeline.md](docs/design/2026_05_24_github_ci_cd_pipeline.md). Stacks on top of [#152](https://github.com/token-overflow/tokenoverflow/pull/152) (already merged).

### Composite actions added (`.github/actions/`)

- **`bun_install`** — pinned Bun `1.3.13`, caches `~/.bun/install/cache` keyed on `bun.lock`, runs `bun install --frozen-lockfile`.
- **`rust_toolchain`** — `toolchain` input (`stable` | `nightly`); installs via `dtolnay/rust-toolchain` + `Swatinem/rust-cache@v2.9.1` with `shared-key: arm64-<toolchain>`.
- **`docker_compose_up`** — `profile` + `tag` inputs; GHCR login, exports `TOKENOVERFLOW_IMAGE_TAG`/`REPO`, pulls and brings up the stack with `--no-build --wait --wait-timeout 600`.
- **`playwright_install`** — `app` input (`landing` | `web`); caches `~/.cache/ms-playwright` keyed on `bun.lock`; installs browsers + OS deps on miss.

### Deploy workflow migrations

- `deploy_api.yml` consumes `./.github/actions/rust_toolchain` (adds Swatinem caching transparently for `cargo lambda build --features bundled-libs`).
- `deploy_landing.yml` and `deploy_web.yml` consume `./.github/actions/bun_install` in place of `oven-sh/setup-bun` + separate install step.

### Design deviations (recorded in the design doc)

- The design's `docker_compose_up` interface bullet (line 730 pre-change) said "Post-step uploads `compose.log`." [Composite actions cannot register post-steps](https://github.com/orgs/community/discussions/26743). Moved log capture to the caller side (Task 7), to be done with [`step-security/gh-docker-logs@v2.2.7`](https://github.com/step-security/gh-docker-logs) on failure only — stdout dump for in-UI debugging + artifact upload with `retention-days: 3` for offline triage.
- Added new Key Decision section "How are e2e Docker logs captured?" capturing the three considered options and the rationale.
- Added `step-security/gh-docker-logs` to the Third Party Dependencies table.

### Composite action input typing — why the `case` validators?

Composite action inputs only support `description` / `required` / `default` / `deprecationMessage` — no `type` field. Reusable workflows (`workflow_call`) support `type: string|boolean|number` but not `choice`. Only `workflow_dispatch:` inputs support `type: choice`. So `rust_toolchain` and `playwright_install` enforce their enum inputs via a small `case` validator at the top of the action.

### SHA pins (verified via GitHub API)

| Action | SHA | Tag |
|---|---|---|
| `Swatinem/rust-cache` | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` | v2.9.1 |
| `docker/login-action` | `c94ce9fb468520275223c153574b00df6fe4bcc9` | v3.7.0 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |

Re-used existing pins for `oven-sh/setup-bun`, `actions/cache`, `dtolnay/rust-toolchain`.

### Drive-by trivy.sh fix (separate commit)

The previous `scripts/src/git_hooks/trivy.sh` wrapper passed only directories to `--skip-dirs` and silently dropped file-only `.gitignore` entries like `.env.local`. Trivy then scanned them and flagged dev secrets, blocking `prek run` on `main`. Fixed by splitting ignored entries into dirs and files and passing both via `--skip-dirs` / `--skip-files`. Test updated accordingly. Per `CLAUDE.md`: "If pre-commit hooks fail, fix it even if it's unrelated to your changes."

## Test plan

- [x] `prek run --verbose` — exit 0
- [x] `act-deploy` / `act-landing` / `act-deploy-web` pre-commit hooks all pass
- [x] `act push -W .github/workflows/deploy_api.yml` end-to-end completes; `cargo lambda build --features bundled-libs` produces the bootstrap binary
- [x] `act push -W .github/workflows/deploy_landing.yml` end-to-end completes; `bun run build:landing` produces `apps/landing/dist/`
- [x] Per-composite YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] SHA pins point at the verified commits (cross-checked via `gh api`)
- [x] `docker compose --profile api up -d --no-build` correctly fails fast on missing GHCR tags (proves `--no-build` is doing its job; CI publish happens in Task 6)
- [x] No stale `compose.log` references remain in any non-design file
- [ ] Cache hit rate verified on a second push to this PR (cold first, warm second)

## Notes

- `act` runs locally hit the `actions/cache` step but always report cache miss because `act` has no GHA cache backend by default. Real cache benchmarking happens once the workflow runs on GitHub.
- `terraform.yml` is intentionally untouched (out of scope per the design).
- The five composite actions land here; `docker_logs` from an earlier iteration was dropped in favor of `step-security/gh-docker-logs` (decided during review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)