### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 3] lint.yml with all jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,217 @@
+name: Lint
+
+on:
+  workflow_call:
+    inputs:
+      rust:
+        description: Lint Rust files
+        type: boolean
+        default: false
+      ts:
+        description: Lint TypeScript files
+        type: boolean
+        default: false
+      shell:
+        description: Lint shell scripts
+        type: boolean
+        default: false
+      markdown:
+        description: Lint markdown files
+        type: boolean
+        default: false
+      terraform:
+        description: Lint terraform files
+        type: boolean
+        default: false
+      api:
+        description: Reserved for downstream gating
+        type: boolean
+        default: false
+      astro:
+        description: Run astro guards
+        type: boolean
+        default: false
+      openapi:
+        description: Check OpenAPI spec drift
+        type: boolean
+        default: false
+      workflows:
+        description: Reserved for orchestrator-wide gating
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      rust:
+        type: boolean
+        default: true
+      ts:
+        type: boolean
+        default: true
+      shell:
+        type: boolean
+        default: true
+      markdown:
+        type: boolean
+        default: true
+      terraform:
+        type: boolean
+        default: true
+      api:
+        type: boolean
+        default: true
+      astro:
+        type: boolean
+        default: true
+      openapi:
+        type: boolean
+        default: true
+      workflows:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust_lint:
+    name: Rust Lint
+    if: inputs.rust
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust nightly toolchain
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: nightly
+
+      - name: Cargo fmt
+        run: cargo +nightly fmt --all -- --check
+
+      - name: Cargo clippy
+        run: cargo +nightly clippy --workspace --tests -- -D warnings
+
+      - name: Cargo machete
+        uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08  # v0.9.2
+
+  ts_lint:
+    name: TypeScript Lint
+    if: inputs.ts
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Turbo `--affected` needs the previous commit to diff against.
+          fetch-depth: 2
+
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
+
+      - name: Turbo lint
+        run: bun run turbo run lint --affected
+
+      - name: Turbo format:check
+        run: bun run turbo run format:check --affected
+
+      - name: Turbo lint:css
+        run: bun run turbo run lint:css --affected
+
+  shell_lint:
+    name: Shell Lint
+    if: inputs.shell
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Shellcheck
+        shell: bash
+        run: |
+          shopt -s globstar
+          shellcheck -x scripts/**/*.sh
+
+  markdown_lint:
+    name: Markdown Lint
+    if: inputs.markdown
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Globs and ignores come from `.markdownlint-cli2.jsonc` (auto-discovered).
+      - name: Markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@fa0cd0f1a052f54da593c83860f2292982f5d142  # v23.2.0
+
+  lychee:
+    name: Lychee
+    if: inputs.markdown
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
+        with:
+          args: --config .lychee.toml --no-progress .
+
+  astro_guards:
+    name: Astro Guards
+    if: inputs.astro
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # `forbid_is_inline.sh` expects files as argv; `forbid_raw_raster_img.sh`
+      # scans the tree itself.
+      - name: Forbid is:inline
+        run: |
+          find apps/landing -type f -name '*.astro' \
+            -exec scripts/src/git_hooks/forbid_is_inline.sh {} +
+
+      - name: Forbid raw raster <img>
+        run: scripts/src/git_hooks/forbid_raw_raster_img.sh
+
+  openapi_drift:
+    name: OpenAPI Drift
+    if: inputs.openapi || inputs.rust
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust stable toolchain
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: stable
+
+      # Project-specific: regenerate openapi.json from utoipa annotations and diff.
+      - name: Check OpenAPI spec drift
+        run: scripts/src/git_hooks/check_openapi_spec_drift.sh
+
+  tflint:
+    name: TFLint
+    if: inputs.terraform
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install tflint
+        uses: terraform-linters/setup-tflint@4cb9feea73331a35b422df102992a03a44a3bb33  # v6.2.1
+        with:
+          tflint_version: v0.62.1
+
+      - name: TFLint
+        run: scripts/src/git_hooks/tflint.sh

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -14,6 +14,13 @@ exclude = [
   "^https://api\\.tokenoverflow\\.io(/|$|#)",
 ]
 
+# Vendored skill content from third parties; links are their problem, not ours.
+exclude_path = [
+  ".agents/skills/postgres",
+  ".agents/skills/turborepo",
+  ".agents/skills/workos",
+]
+
 # Allow private loopbacks to keep the test harness simple.
 exclude_loopback = false
 

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,16 @@
+// Single source of truth for markdownlint-cli2 globs/ignores; shared by
+// pre-commit and CI. Rules live in the sibling `.markdownlint.json`,
+// auto-discovered by cli2.
+{
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    ".github",
+    ".agents/skills/postgres",
+    ".agents/skills/turborepo",
+    ".agents/skills/workos"
+  ],
+  // Skip files matched by `.gitignore` (covers `node_modules/`, `target/`, etc.).
+  "gitignore": true
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,11 +34,11 @@ repos:
       - id: no-commit-to-branch
       - id: trailing-whitespace
         exclude_types: [ markdown ]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360  # v0.45.0
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: 996abf60411a8d954288ac9856aae7602b80cbda  # v0.22.1
     hooks:
-      - id: markdownlint
-        exclude: (^\.github/|^\.opencode/|^\.agents/)
+      - id: markdownlint-cli2
+        args: [--no-globs]
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 38980559e3a605691d6579f96222c30778e5a69e  # 3.0.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,10 @@ be used:
 3. The human reviews the design document and provides feedback until approval.
 4. The `engineer` agent implements the design using the `implement-design` skill.
     a. Design is implemented as a series of stacked PRs, one per vertical task.
-    b. Each PR is reviewed by the `code-reviewer` agent using the `code-review` skill.
-    c. The `engineer` iterates on the implementation until the `code-reviewer` approves.
+    b. Each PR is reviewed by the `code-reviewer` agent using the
+       `code-review` skill.
+    c. The `engineer` iterates on the implementation until the `code-reviewer`
+       approves.
     d. The human reviews the final changes.
     e. The `engineer` iterates until the human approves.
 

--- a/docs/design/2026_05_23_claude_plugin_marketplace.md
+++ b/docs/design/2026_05_23_claude_plugin_marketplace.md
@@ -250,7 +250,7 @@ git tag (e.g. `v0.0.1`) on push.
 
 **Rationale:** Rejected. Premature automation.
 
-### Decision 3: Fix the `${CLAUDE_PLUGIN_ROOT}/instructions.md` cross-directory reference
+### Decision 3: Fix the cross-directory reference in `${CLAUDE_PLUGIN_ROOT}`
 
 Today `integrations/claude/hooks/hooks.json` reads
 `${CLAUDE_PLUGIN_ROOT}/instructions.md`. There is a symlink at


### PR DESCRIPTION
## Summary

- Add [`.github/workflows/lint.yml`](.github/workflows/lint.yml): reusable workflow with 8 parallel jobs (rust_lint, ts_lint, shell_lint, markdown_lint, lychee, astro_guards, openapi_drift, tflint), gated by per-surface boolean inputs. Triggerable via `workflow_call` (for the upcoming `pr.yml` orchestrator) and `workflow_dispatch` (for manual validation in the interim).
- Dedupe markdownlint config: pre-commit and CI both consume `.markdownlint-cli2.jsonc`. Pre-commit hook switched from `igorshubovych/markdownlint-cli` to `DavidAnson/markdownlint-cli2`.
- Exclude vendored third-party skill content (`postgres`, `turborepo`, `workos`) from lychee and markdownlint to avoid false positives.

Implements Task 3 of [`docs/design/2026_05_24_github_ci_cd_pipeline.md`](docs/design/2026_05_24_github_ci_cd_pipeline.md).

## Test plan

- [ ] `prek run --verbose` exits 0
- [ ] `gh workflow run lint.yml --ref feature/github-ci-cd-pipeline-3` — all 8 jobs green
- [ ] Targeted dispatch with only `rust=true` — only `rust_lint` + `openapi_drift` run; others skipped
- [ ] Trigger a deliberate lint failure (e.g. add an over-long markdown heading) and confirm `markdown_lint` red

🤖 Generated with [Claude Code](https://claude.com/claude-code)