### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 3.1] Fix lint.yml CI failures

### DIFF
--- a/.agents/skills/implement-design/SKILL.md
+++ b/.agents/skills/implement-design/SKILL.md
@@ -8,9 +8,10 @@ description: You **must** use this when implementing the code for an approved de
 ## Workflow
 
 1. Read the entire design document end to end.
-2. All tasks from the design document will be implemented as stacked PRs. For every task:
-    a. Create branch `feature/{{design-title}}-{{n}}` rebased from the previous task branch
-        or the latest `origin/main` if it's the first task.
+2. All tasks from the design document will be implemented as stacked PRs.
+    For every task:
+    a. Create branch `feature/{{design-title}}-{{n}}` rebased from the
+        previous task branch or the latest `origin/main` if it's the first task.
     b. Implement the task using the guidelines below.
     c. Use `/code-review` skill to get feedback and iterate until it's perfect.
     d. **CRITICAL:** Ask for user's final approval. Iterate until approved.
@@ -47,29 +48,33 @@ You **must** follow these guidelines at all times:
         - Integration: In-process integration tests with external dependencies
         - E2E: Black-box testing of the whole system based on user stories
     - Domain Driven Design (DDD):
-        - Use entities, value objects, aggregates, repositories, and services to model
-        complex domains.
-        - Use ubiquitous language that is shared between developers and domain experts.
+        - Use entities, value objects, aggregates, repositories, and services
+        to model complex domains.
+        - Use ubiquitous language that is shared between developers and domain
+        experts.
     - Functional Core, Imperative Shell (FCIS):
         - Functional core: Unit testable business logic
         - Imperative shell: External dependencies like I/O, use integration tests
     - Hexagonal Architecture
         - Core business logic is isolated from external systems, allowing easy swapping.
     - SOLID Principles
-        - Single Responsibility Principle (SRP): A class should have one job or purpose.
-        - Open-Closed Principle (OCP): New features should be added by adding new code, not
-        modifying existing code.
-        - Liskov Substitution Principle (LSP): Subclasses must behave in a way that doesn't
-        break the functionality of the parent class.
-        - Interface Segregation Principle (ISP): Create smaller, specific interfaces rather than
-        one large, general-purpose one.
-        - Dependency Inversion Principle (DIP): High-level modules should not depend on low-level
-        modules; both should depend on abstractions (interfaces).
+        - Single Responsibility Principle (SRP): A class should have one job
+        or purpose.
+        - Open-Closed Principle (OCP): New features should be added by adding
+        new code, not modifying existing code.
+        - Liskov Substitution Principle (LSP): Subclasses must behave in a way
+        that doesn't break the functionality of the parent class.
+        - Interface Segregation Principle (ISP): Create smaller, specific
+        interfaces rather than one large, general-purpose one.
+        - Dependency Inversion Principle (DIP): High-level modules should not
+        depend on low-level modules; both should depend on abstractions
+        (interfaces).
     - Clean Code
         - No duplication
         - Readable over clever
-        - Comments only when necessary. Explain the why not the what. Make sure it's easy to
-        understand for people with no context, don't make it too information dense.
+        - Comments only when necessary. Explain the why not the what. Make
+        sure it's easy to understand for people with no context, don't make it
+        too information dense.
         - Clear separation of concerns
 
 ## Validation

--- a/.github/actions/rust_toolchain/action.yml
+++ b/.github/actions/rust_toolchain/action.yml
@@ -7,6 +7,10 @@ inputs:
   toolchain:
     description: Rust toolchain to install (`stable` or `nightly`).
     required: true
+  components:
+    description: Comma-separated rustup components (e.g. `rustfmt, clippy`).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -25,6 +29,7 @@ runs:
       uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9  # stable
       with:
         toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
 
     # `shared-key` keeps the cache stable across jobs; arch + toolchain
     # avoid cross-poisoning between stable and nightly.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,6 +86,7 @@ jobs:
         uses: ./.github/actions/rust_toolchain
         with:
           toolchain: nightly
+          components: rustfmt, clippy
 
       - name: Cargo fmt
         run: cargo +nightly fmt --all -- --check
@@ -194,6 +195,11 @@ jobs:
         uses: ./.github/actions/rust_toolchain
         with:
           toolchain: stable
+
+      # Release build links against system libpq; not preinstalled on
+      # `ubuntu-24.04-arm`. Mac dev hosts get libpq via Homebrew.
+      - name: Install libpq
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
 
       # Project-specific: regenerate openapi.json from utoipa annotations and diff.
       - name: Check OpenAPI spec drift

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,9 @@ exclude = [
   # lychee hits 403/429 on cold caches.
   "^https://github\\.com/.*/raw/",
 
+  # Cloudflare dashboard is auth-only; unauthenticated requests get 403.
+  "^https://dash\\.cloudflare\\.com",
+
   # TODO: remove once tokenoverflow.io is live (tracked in
   # docs/design/2026_04_20_landing_page.md).
   "^https://tokenoverflow\\.io(/|$|#)",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -7,6 +7,9 @@
   ],
   "ignores": [
     ".github",
+    // `.claude/skills` is a symlink to `.agents/skills`; skip to avoid
+    // double-scanning vendored content under both paths.
+    ".claude",
     ".agents/skills/postgres",
     ".agents/skills/turborepo",
     ".agents/skills/workos"

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# Mock functions inside bashunit set_up/tear_down look unreachable to static
+# analysis but are invoked indirectly when sourced tests run.
+disable=SC2317

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,0 @@
-# Mock functions inside bashunit set_up/tear_down look unreachable to static
-# analysis but are invoked indirectly when sourced tests run.
-disable=SC2317

--- a/scripts/tests/.shellcheckrc
+++ b/scripts/tests/.shellcheckrc
@@ -1,3 +1,3 @@
 # Mock functions in tests are invoked indirectly via the sourced scripts under
 # test, so shellcheck cannot see the call sites.
-disable=SC2329
+disable=SC2317,SC2329


### PR DESCRIPTION
Stacked fix for [#154](https://github.com/token-overflow/tokenoverflow/pull/154). Run https://github.com/token-overflow/tokenoverflow/actions/runs/26416258410 surfaced 5 distinct failures; this PR addresses each.

## Fixes

1. **rust_lint — `cargo fmt` missing rustfmt**: `rust_toolchain` composite installed nightly with the minimal profile (no rustfmt/clippy). Added an optional `components` input to the composite; `lint.yml` passes `rustfmt, clippy` from the rust_lint job. openapi_drift's call site is unchanged.
2. **lychee — Cloudflare dashboard 403**: `https://dash.cloudflare.com/` returns 403 to unauthenticated requests. Added to the URL exclude list in [`.lychee.toml`](.lychee.toml).
3. **shellcheck — SC2317 noise**: bashunit mock functions look unreachable to static analysis. Suppressed via the existing [`scripts/tests/.shellcheckrc`](scripts/tests/.shellcheckrc) (`SC2317` appended next to the existing `SC2329` disable).
4. **openapi_drift — `cannot find -lpq`**: `cargo run --release` links against system libpq, which isn't preinstalled on `ubuntu-24.04-arm`. Added a `sudo apt-get install -y libpq-dev` step before the drift check. (`deploy_api.yml` uses `--features bundled-libs`; no script change.)
5. **markdown_lint — symlink dupes + 1 real file**: `.claude/skills` is a symlink to `.agents/skills`, so cli2 scanned vendored content twice. Added `.claude` to ignores. Also wrapped 9 over-long lines in [`.agents/skills/implement-design/SKILL.md`](.agents/skills/implement-design/SKILL.md) that were exposed once the previous broad `.agents/` ignore was narrowed.

## Verification

CI run on this branch: https://github.com/token-overflow/tokenoverflow/actions/runs/26416930916 — all 8 jobs green (rust_lint, ts_lint, shell_lint, markdown_lint, lychee, astro_guards, openapi_drift, tflint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)