### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 4] type_check + unit_test + integration_test + security_audit reusables

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,35 @@
+name: Integration Test
+
+on:
+  workflow_call:
+    inputs:
+      rust:
+        description: Run Rust integration tests
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      rust:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  rust_integration:
+    name: Rust Integration
+    if: inputs.rust
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust stable toolchain
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: stable
+
+      - name: Cargo test integration
+        run: cargo test --workspace --test integration

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,90 @@
+name: Security Audit
+
+on:
+  workflow_call:
+    inputs:
+      rust:
+        description: Run cargo audit
+        type: boolean
+        default: false
+      ts:
+        description: Run bun audit
+        type: boolean
+        default: false
+      docker:
+        description: Run Trivy when Docker assets changed
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      rust:
+        type: boolean
+        default: true
+      ts:
+        type: boolean
+        default: true
+      docker:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Trivy Filesystem Scan
+    if: inputs.rust || inputs.ts || inputs.docker
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514  # v0.2.6
+        with:
+          version: v0.70.0
+
+      - name: Trivy fs scan
+        run: scripts/src/git_hooks/trivy.sh
+
+  cargo_audit:
+    name: Cargo Audit
+    if: inputs.rust
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust stable toolchain
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Report all advisories
+        run: cargo audit --deny warnings || true
+
+      - name: Fail on vulnerabilities
+        run: cargo audit
+
+  bun_audit:
+    name: Bun Audit
+    if: inputs.ts
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
+
+      - name: Report all advisories
+        run: bun audit || true
+
+      - name: Fail on critical advisories
+        run: bun audit --audit-level=critical

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -1,0 +1,36 @@
+name: Type Check
+
+on:
+  workflow_call:
+    inputs:
+      ts:
+        description: Type-check TypeScript packages
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      ts:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  type_check:
+    name: Type Check
+    if: inputs.ts
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Turbo `--affected` needs the previous commit to diff against.
+          fetch-depth: 2
+
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
+
+      - name: Turbo check
+        run: bun run turbo run check --affected

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,0 +1,82 @@
+name: Unit Test
+
+on:
+  workflow_call:
+    inputs:
+      rust:
+        description: Run Rust unit tests
+        type: boolean
+        default: false
+      ts:
+        description: Run TypeScript unit tests
+        type: boolean
+        default: false
+      shell:
+        description: Run shell unit tests
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      rust:
+        type: boolean
+        default: true
+      ts:
+        type: boolean
+        default: true
+      shell:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  vitest_unit:
+    name: Vitest Unit
+    if: inputs.ts
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Turbo `--affected` needs the previous commit to diff against.
+          fetch-depth: 2
+
+      - name: Install Bun & dependencies
+        uses: ./.github/actions/bun_install
+
+      - name: Turbo test:coverage
+        run: bun run turbo run test:coverage --affected
+
+  cargo_test_unit:
+    name: Cargo Test Unit
+    if: inputs.rust
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust stable toolchain
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: stable
+
+      - name: Cargo test
+        run: cargo test --workspace --lib --test unit
+
+  bashunit:
+    name: Bash Unit
+    if: inputs.shell
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install bashunit
+        run: curl -s https://bashunit.typeddevs.com/install.sh | bash
+
+      - name: Run bashunit tests
+        run: find scripts/tests -type f -name 'test_*.sh' -exec ./lib/bashunit {} +

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=linux/arm64 rust:1.93-slim AS chef
 WORKDIR /app
 
 # Install build dependencies needed for cargo-chef and compilation
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     libpq-dev \
@@ -58,7 +58,7 @@ RUN strip /app/target/release/tokenoverflow
 # =============================================================================
 FROM --platform=linux/arm64 debian:trixie-slim AS runtime
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3 \
     libpq5 \

--- a/apps/embedding_service/Dockerfile
+++ b/apps/embedding_service/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.93-slim AS chef
 WORKDIR /app
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     g++ \
@@ -55,7 +55,7 @@ RUN cargo build --release -p embedding_service
 FROM debian:trixie-slim AS runtime
 
 # Install runtime dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl3 \
     curl \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -38,6 +38,8 @@ WORKDIR /app
 # no need to ship node_modules.
 COPY --from=builder /app/apps/web/.output ./.output
 
+USER node
+
 EXPOSE 3000
 
 CMD ["node", ".output/server/index.mjs"]

--- a/infra/docker/diesel/Dockerfile
+++ b/infra/docker/diesel/Dockerfile
@@ -1,7 +1,11 @@
 FROM rust:1.93-slim
 
-RUN apt-get update && apt-get install -y libpq-dev && rm -rf /var/lib/apt/lists/*
-RUN cargo install diesel_cli --no-default-features --features postgres
+RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN rustup component add rustfmt
+RUN cargo install diesel_cli --version 2.3.8 --no-default-features --features postgres
+
+RUN useradd -r -u 1001 diesel
+USER diesel
 
 WORKDIR /volume
 

--- a/infra/terraform/modules/bastion/main.tf
+++ b/infra/terraform/modules/bastion/main.tf
@@ -28,6 +28,8 @@ resource "aws_security_group" "bastion" {
   }
 }
 
+# TODO(#156): https://github.com/token-overflow/tokenoverflow/issues/156
+# trivy:ignore:AWS-0104
 resource "aws_vpc_security_group_egress_rule" "all_outbound" {
   security_group_id = aws_security_group.bastion.id
   description       = "Allow all outbound traffic (SSM agent, DB access)"

--- a/infra/terraform/modules/lambda/s3.tf
+++ b/infra/terraform/modules/lambda/s3.tf
@@ -1,3 +1,10 @@
+# TODO(#157): https://github.com/token-overflow/tokenoverflow/issues/157
+# TODO(#158): https://github.com/token-overflow/tokenoverflow/issues/158
+# trivy:ignore:AWS-0086
+# trivy:ignore:AWS-0087
+# trivy:ignore:AWS-0091
+# trivy:ignore:AWS-0093
+# trivy:ignore:AWS-0132
 resource "aws_s3_bucket" "deployments" {
   bucket = "tokenoverflow-lambda-${var.env_name}"
 

--- a/infra/terraform/modules/lambda/security_groups.tf
+++ b/infra/terraform/modules/lambda/security_groups.tf
@@ -10,6 +10,8 @@ resource "aws_security_group" "lambda" {
   }
 }
 
+# TODO(#156): https://github.com/token-overflow/tokenoverflow/issues/156
+# trivy:ignore:AWS-0104
 resource "aws_vpc_security_group_egress_rule" "lambda_all_outbound" {
   security_group_id = aws_security_group.lambda.id
   description       = "Allow all outbound traffic"

--- a/infra/terraform/modules/landing/cloudfront.tf
+++ b/infra/terraform/modules/landing/cloudfront.tf
@@ -126,6 +126,8 @@ resource "aws_cloudfront_cache_policy" "short" {
   }
 }
 
+# TODO(#159): https://github.com/token-overflow/tokenoverflow/issues/159
+# trivy:ignore:AWS-0011
 resource "aws_cloudfront_distribution" "landing" {
   enabled             = true
   is_ipv6_enabled     = true

--- a/infra/terraform/modules/landing/s3.tf
+++ b/infra/terraform/modules/landing/s3.tf
@@ -1,3 +1,5 @@
+# TODO(#158): https://github.com/token-overflow/tokenoverflow/issues/158
+# trivy:ignore:AWS-0132
 resource "aws_s3_bucket" "landing" {
   bucket = var.bucket_name
 }

--- a/infra/terraform/modules/nat/main.tf
+++ b/infra/terraform/modules/nat/main.tf
@@ -8,6 +8,8 @@ resource "aws_eip" "nat" {
   }
 }
 
+# TODO(#156): https://github.com/token-overflow/tokenoverflow/issues/156
+# trivy:ignore:AWS-0104
 module "fck_nat" {
   source  = "RaJiska/fck-nat/aws"
   version = "1.4.0"

--- a/infra/terraform/modules/pgbouncer/security_groups.tf
+++ b/infra/terraform/modules/pgbouncer/security_groups.tf
@@ -33,6 +33,8 @@ resource "aws_vpc_security_group_ingress_rule" "pgbouncer-from-bastion" {
 }
 
 # Egress: Allow all outbound traffic (SSM agent, package repos, RDS)
+# TODO(#156): https://github.com/token-overflow/tokenoverflow/issues/156
+# trivy:ignore:AWS-0104
 resource "aws_vpc_security_group_egress_rule" "all-outbound" {
   security_group_id = aws_security_group.pgbouncer.id
   description       = "Allow all outbound traffic (SSM agent, package repos, RDS)"

--- a/infra/terraform/modules/web/security_group.tf
+++ b/infra/terraform/modules/web/security_group.tf
@@ -10,6 +10,8 @@ resource "aws_security_group" "web" {
   }
 }
 
+# TODO(#156): https://github.com/token-overflow/tokenoverflow/issues/156
+# trivy:ignore:AWS-0104
 resource "aws_vpc_security_group_egress_rule" "web_https_outbound" {
   security_group_id = aws_security_group.web.id
   description       = "Allow HTTPS to AuthKit and the API"

--- a/scripts/src/git_hooks/trivy.sh
+++ b/scripts/src/git_hooks/trivy.sh
@@ -10,7 +10,7 @@ ENTRIES=$(git ls-files --others --ignored --exclude-standard --directory)
 SKIP_DIRS=$(awk '/\/$/ { sub(/\/$/, ""); print }' <<<"$ENTRIES" | paste -sd ',' -)
 SKIP_FILES=$(awk '!/\/$/' <<<"$ENTRIES" | paste -sd ',' -)
 
-ARGS=(fs --disable-telemetry --exit-code 1 --severity='HIGH,CRITICAL')
+ARGS=(fs --disable-telemetry --exit-code 1 --severity='HIGH,CRITICAL' --scanners='vuln,secret,misconfig')
 [ -n "$SKIP_DIRS" ] && ARGS+=(--skip-dirs "$SKIP_DIRS")
 [ -n "$SKIP_FILES" ] && ARGS+=(--skip-files "$SKIP_FILES")
 

--- a/scripts/tests/git_hooks/test_trivy.sh
+++ b/scripts/tests/git_hooks/test_trivy.sh
@@ -42,7 +42,7 @@ function test_passes_through_when_no_ignored_dirs_exist() {
   git commit -q -m init
   local output
   output="$("$HOOK_SCRIPT")"
-  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL ." "$output"
+  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --scanners=vuln,secret,misconfig ." "$output"
 }
 
 function test_includes_single_ignored_dir() {
@@ -53,7 +53,7 @@ function test_includes_single_ignored_dir() {
   git commit -q -m init
   local output
   output="$("$HOOK_SCRIPT")"
-  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --skip-dirs build ." "$output"
+  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --scanners=vuln,secret,misconfig --skip-dirs build ." "$output"
 }
 
 function test_joins_multiple_ignored_dirs_with_commas() {
@@ -78,7 +78,7 @@ function test_passes_file_only_gitignore_entries_via_skip_files() {
   git commit -q -m init
   local output
   output="$("$HOOK_SCRIPT")"
-  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --skip-dirs build --skip-files .DS_Store ." "$output"
+  assert_same "trivy fs --disable-telemetry --exit-code 1 --severity=HIGH,CRITICAL --scanners=vuln,secret,misconfig --skip-dirs build --skip-files .DS_Store ." "$output"
 }
 
 function test_handles_nested_ignored_dirs() {


### PR DESCRIPTION
## Summary

Adds the four reusable workflows from Task 4 of the [CI/CD Pipeline design](docs/design/2026_05_24_github_ci_cd_pipeline.md): `type_check.yml`, `unit_test.yml`, `integration_test.yml`, and `security_audit.yml`. Each consumes the composite actions from Task 2 and matches the equivalent pre-commit hook command for parity. No orchestrator wiring yet (Task 5).

### Reusables

- **`type_check.yml`** — single job: `bun run turbo run check --affected`.
- **`unit_test.yml`** — three parallel jobs:
  - `vitest_unit`: `bun run turbo run test:coverage --affected`.
  - `cargo_test_unit`: `cargo test --workspace --lib --test unit` (scopes to unit-only; integration/e2e are owned by other reusables).
  - `bashunit`: installs via the official `bashunit.typeddevs.com/install.sh` snippet per the docs, then `find scripts/tests -type f -name 'test_*.sh' -exec ./lib/bashunit {} +`.
- **`integration_test.yml`** — single `rust_integration` job: `cargo test --workspace --test integration`. (TS leg deferred: `apps/web/vitest.config.ts` already globs `tests/integration/**` into the unit run.)
- **`security_audit.yml`** — three parallel jobs:
  - `trivy`: invokes `scripts/src/git_hooks/trivy.sh`, the same wrapper the pre-commit hook uses (skips gitignored paths via `git ls-files`).
  - `cargo_audit`: two-pass (`cargo audit --deny warnings || true` then `cargo audit`).
  - `bun_audit`: two-pass (`bun audit || true` then `bun audit --audit-level=critical`).

Every reusable has both `workflow_call` and `workflow_dispatch` triggers with per-surface boolean inputs, `runs-on: ubuntu-24.04-arm`, `permissions: contents: read`, and per-design timeouts.

### Trivy misconfig scanning + Dockerfile hardening

Enabled IaC misconfig scanning in both the pre-commit `trivy.sh` and CI: `--scanners='vuln,secret,misconfig'`. Dockerfile findings fixed inline (`--no-install-recommends` on api/embedding_service/diesel; non-root `USER` on web and diesel). Terraform findings tracked via inline `# trivy:ignore:RULE_ID` + `# TODO(#N):` comments linking to four new GitHub issues:

- [#156](https://github.com/token-overflow/tokenoverflow/issues/156) — AWS-0104 unrestricted egress (bastion, lambda, pgbouncer, web, nat-module call)
- [#157](https://github.com/token-overflow/tokenoverflow/issues/157) — S3 public access block on lambda artifacts bucket
- [#158](https://github.com/token-overflow/tokenoverflow/issues/158) — S3 customer-managed KMS on lambda + landing buckets
- [#159](https://github.com/token-overflow/tokenoverflow/issues/159) — CloudFront WAF on landing distribution

### Side fixes

- **`infra/docker/diesel/Dockerfile`**: pinned `diesel_cli` to `2.3.8` and added `rustup component add rustfmt`. Root cause: `rust:1.93-slim` ships a `rustfmt` shim without the actual component, so diesel CLI fell back to unformatted single-line `print-schema` output. Now `migration redo --all` produces a `schema.rs` identical to the committed file across rebuilds.
- **`scripts/tests/git_hooks/test_trivy.sh`**: assertion fixtures updated for the new `--scanners` flag.

### Deviations from the design

- **Trivy action**: the design's Third Party table lists `aquasecurity/trivy-action`; this PR uses `aquasecurity/setup-trivy@v0.2.6` with an explicitly pinned `trivy v0.70.0` CLI. Defensive against the March 2026 `trivy-action` supply-chain tag-move incident; behavior is identical.
- **`cargo_test_unit` scope**: design says `cargo test --workspace`. Plain `--workspace` runs the `integration` and `e2e` test binaries too; we scope to `--lib --test unit` to match `scripts/src/git_hooks/cargo_coverage.sh` and keep tier ownership clean.

## Test plan

- [x] `prek run` exit 0 locally (with Compose stack up for the existing `turbo-test-e2e` hook).
- [x] Each workflow's command runs green locally: `bun run turbo run check --affected`, `bun run turbo run test:coverage --affected`, `cargo test --workspace --lib --test unit` (242 pass), `cargo test --workspace --test integration` (156 pass), `find scripts/tests ... bashunit` (101 pass), `scripts/src/git_hooks/trivy.sh` (exit 0), `cargo audit` (exit 0), `bun audit --audit-level=critical` (exit 0).
- [x] `gh api .../contents/.github/workflows?ref=feature/github-ci-cd-pipeline-4` lists all four files; YAML schema validated by the `check-yaml` pre-commit hook.
- [ ] Post-merge: `gh workflow run type_check.yml` / `unit_test.yml` / `integration_test.yml` / `security_audit.yml` against `main` and confirm each runs green. (`workflow_dispatch` requires the files on the default branch first, so this is post-merge only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)