### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 4.1] Fix CI failures: install libpq-dev and chain gen:api-client

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # diesel `postgres` feature links against libpq at test time. Deploy
+      # workflows side-step this via `--features bundled-libs`; tests don't.
+      - name: Install libpq
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+
       - name: Install Rust stable toolchain
         uses: ./.github/actions/rust_toolchain
         with:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # diesel `postgres` feature links against libpq at test time. Deploy
+      # workflows side-step this via `--features bundled-libs`; tests don't.
+      - name: Install libpq
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+
       - name: Install Rust stable toolchain
         uses: ./.github/actions/rust_toolchain
         with:

--- a/turbo.json
+++ b/turbo.json
@@ -20,10 +20,10 @@
       "persistent": true
     },
     "check": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "gen:api-client"]
     },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "gen:api-client"]
     },
     "lint:css": {},
     "format:check": {},
@@ -33,11 +33,11 @@
       "dependsOn": ["build"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "gen:api-client"],
       "outputs": []
     },
     "test:coverage": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "gen:api-client"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "!tests/e2e/**",


### PR DESCRIPTION
## Summary

Hotfix for two CI failures uncovered when dispatching the Part 4 reusables on `ubuntu-24.04-arm`. Both runs are now green on this branch.

### 1. `cargo test` linker failure: cannot find -lpq

`apps/api` and `apps/so_tag_sync` enable diesel's `postgres` feature, which links against system `libpq` at compile time. Deploy workflows sidestep this with `cargo lambda build --features bundled-libs`; tests do not. The `ubuntu-24.04-arm` runner image does not ship `libpq-dev`, so the linker fails on the dependency `-lpq`.

Fix: add a targeted `apt-get install -y --no-install-recommends libpq-dev` step before `cargo test` in two jobs:
- `.github/workflows/unit_test.yml` -> `cargo_test_unit`
- `.github/workflows/integration_test.yml` -> `rust_integration`

The install is scoped to compile-time jobs. `cargo_audit` does not compile, so it does not pay the apt cost.

### 2. Vitest could not find `_generated/sdk.gen`

`turbo.json` listed `^build` (upstream packages) but not `gen:api-client` (same-package) under `dependsOn` for `check`, `lint`, `test`, and `test:coverage`. Locally `apps/web/src/utils/api/_generated/` exists from prior builds; on a clean CI checkout it does not, so the import in `apps/web/src/utils/api/waitlist.server.ts` resolves nothing.

Fix: add `gen:api-client` to the `dependsOn` of `check`, `lint`, `test`, and `test:coverage`. The task is `cache: true` and only re-runs when `apps/api/openapi.json` changes.

## Verification

- [x] Local `bun run turbo run test:coverage --filter=@tokenoverflow/web` after `rm -rf apps/web/src/utils/api/_generated`: SDK regenerated, all 78 tests pass.
- [x] CI dispatch on this branch: [`Unit Test` run 26421715632](https://github.com/token-overflow/tokenoverflow/actions/runs/26421715632) and [`Integration Test` run 26421532961](https://github.com/token-overflow/tokenoverflow/actions/runs/26421532961) both green.
- [x] `prek run --verbose` exit 0.

## Test plan

- [ ] Post-merge: re-dispatch `Unit Test` and `Integration Test` against `main` and confirm green (workflow_dispatch defaults exercise every job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)