### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 5] pr.yml orchestrator (fast bucket only)

### DIFF
--- a/.github/act/event_pr.json
+++ b/.github/act/event_pr.json
@@ -3,13 +3,17 @@
   "action": "opened",
   "pull_request": {
     "head": {
-      "ref": "feature-branch"
+      "ref": "feature-branch",
+      "repo": {
+        "full_name": "token-overflow/tokenoverflow"
+      }
     },
     "base": {
       "ref": "main"
     }
   },
   "repository": {
-    "default_branch": "main"
+    "default_branch": "main",
+    "full_name": "token-overflow/tokenoverflow"
   }
 }

--- a/.github/actions/rust_toolchain/action.yml
+++ b/.github/actions/rust_toolchain/action.yml
@@ -25,6 +25,9 @@ runs:
       uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9  # stable
       with:
         toolchain: ${{ inputs.toolchain }}
+        # `nightly` ships without rustfmt or clippy by default; both are
+        # used by `lint.yml` against the nightly toolchain.
+        components: rustfmt, clippy
 
     # `shared-key` keeps the cache stable across jobs; arch + toolchain
     # avoid cross-poisoning between stable and nightly.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -190,6 +190,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      # The drift check compiles the api binary, which links against libpq.
+      - name: Install libpq
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+
       - name: Install Rust stable toolchain
         uses: ./.github/actions/rust_toolchain
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,169 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      ts: ${{ steps.filter.outputs.ts }}
+      landing: ${{ steps.filter.outputs.landing }}
+      web: ${{ steps.filter.outputs.web }}
+      api: ${{ steps.filter.outputs.api }}
+      embedding: ${{ steps.filter.outputs.embedding }}
+      docker: ${{ steps.filter.outputs.docker }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      terraform: ${{ steps.filter.outputs.terraform }}
+      shell: ${{ steps.filter.outputs.shell }}
+      markdown: ${{ steps.filter.outputs.markdown }}
+      openapi: ${{ steps.filter.outputs.openapi }}
+      astro: ${{ steps.filter.outputs.astro }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Per-surface inclusions
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        with:
+          filters: |
+            rust:
+              - 'apps/api/**'
+              - 'apps/embedding_service/**'
+              - 'apps/so_tag_sync/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            ts:
+              - 'apps/web/**'
+              - 'apps/landing/**'
+              - 'packages/**'
+              - 'apps/api/openapi.json'
+              - 'bun.lock'
+              - 'bunfig.toml'
+              - 'turbo.json'
+            landing:
+              - 'apps/landing/**'
+            web:
+              - 'apps/web/**'
+            api:
+              - 'apps/api/**'
+            embedding:
+              - 'apps/embedding_service/**'
+            docker:
+              - 'docker-compose.yml'
+              - 'apps/*/Dockerfile'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+            terraform:
+              - 'terraform/**'
+              - '**/*.tf'
+              - '**/*.tftpl'
+            shell:
+              - '**/*.sh'
+              - 'scripts/**'
+            markdown:
+              - '**/*.md'
+              - '**/*.mdx'
+            openapi:
+              - 'apps/api/openapi.json'
+            astro:
+              - 'apps/landing/**/*.astro'
+
+  lint:
+    needs: prepare
+    if: |
+      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+      needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.markdown == 'true' ||
+      needs.prepare.outputs.terraform == 'true' || needs.prepare.outputs.astro == 'true' ||
+      needs.prepare.outputs.openapi == 'true' || needs.prepare.outputs.workflows == 'true'
+    uses: ./.github/workflows/lint.yml
+    with:
+      rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      ts: ${{ needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      shell: ${{ needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      markdown: ${{ needs.prepare.outputs.markdown == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      terraform: ${{ needs.prepare.outputs.terraform == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      astro: ${{ needs.prepare.outputs.astro == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      openapi: ${{ needs.prepare.outputs.openapi == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      workflows: ${{ needs.prepare.outputs.workflows == 'true' }}
+    secrets: inherit
+
+  type_check:
+    needs: prepare
+    if: needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true'
+    uses: ./.github/workflows/type_check.yml
+    with:
+      ts: ${{ needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true' }}
+    secrets: inherit
+
+  unit_test:
+    needs: prepare
+    if: |
+      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+      needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true'
+    uses: ./.github/workflows/unit_test.yml
+    with:
+      rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      ts: ${{ needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      shell: ${{ needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true' }}
+    secrets: inherit
+
+  integration_test:
+    needs: prepare
+    if: needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true'
+    uses: ./.github/workflows/integration_test.yml
+    with:
+      rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
+    secrets: inherit
+
+  security_audit:
+    needs: prepare
+    if: |
+      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+      needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true'
+    uses: ./.github/workflows/security_audit.yml
+    with:
+      rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      ts: ${{ needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true' }}
+      docker: ${{ needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true' }}
+    secrets: inherit
+
+  required:
+    name: Required
+    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit ]
+    if: always()
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Fail if conditional jobs failed
+        if: |
+          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+            needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.markdown == 'true' ||
+            needs.prepare.outputs.terraform == 'true' || needs.prepare.outputs.astro == 'true' ||
+            needs.prepare.outputs.openapi == 'true' || needs.prepare.outputs.workflows == 'true') &&
+           needs.lint.result != 'success') ||
+          ((needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true') &&
+           needs.type_check.result != 'success') ||
+          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+            needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true') &&
+           needs.unit_test.result != 'success') ||
+          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true') &&
+           needs.integration_test.result != 'success') ||
+          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
+            needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true') &&
+           needs.security_audit.result != 'success')
+        run: exit 1

--- a/.github/workflows/type_check.yml
+++ b/.github/workflows/type_check.yml
@@ -29,6 +29,13 @@ jobs:
           # Turbo `--affected` needs the previous commit to diff against.
           fetch-depth: 2
 
+      # `astro check` shells out via Node and enforces Node >= 22.12.
+      # `ubuntu-24.04-arm` ships Node 20 by default.
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+
       - name: Install Bun & dependencies
         uses: ./.github/actions/bun_install
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,9 @@ exclude = [
   # lychee hits 403/429 on cold caches.
   "^https://github\\.com/.*/raw/",
 
+  # Cloudflare dashboard rejects unauthenticated bot traffic with 403.
+  "^https://dash\\.cloudflare\\.com",
+
   # TODO: remove once tokenoverflow.io is live (tracked in
   # docs/design/2026_04_20_landing_page.md).
   "^https://tokenoverflow\\.io(/|$|#)",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -7,9 +7,9 @@
   ],
   "ignores": [
     ".github",
-    ".agents/skills/postgres",
-    ".agents/skills/turborepo",
-    ".agents/skills/workos"
+    // Skill prose follows author/upstream conventions, not project lint rules.
+    ".agents/skills",
+    ".claude/skills"
   ],
   // Skip files matched by `.gitignore` (covers `node_modules/`, `target/`, etc.).
   "gitignore": true

--- a/scripts/tests/.shellcheckrc
+++ b/scripts/tests/.shellcheckrc
@@ -1,3 +1,4 @@
 # Mock functions in tests are invoked indirectly via the sourced scripts under
-# test, so shellcheck cannot see the call sites.
-disable=SC2329
+# test, so shellcheck cannot see the call sites. SC2317 fires on the same
+# pattern when shellcheck cannot trace function bodies through bashunit.
+disable=SC2329,SC2317

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "gen:api-client"],
-      "outputs": ["dist/**", ".output/**"]
+      "outputs": ["dist/**", ".output/**", "src/routeTree.gen.ts"]
     },
     "gen:api-client": {
       "inputs": [
@@ -20,7 +20,7 @@
       "persistent": true
     },
     "check": {
-      "dependsOn": ["^build", "gen:api-client"]
+      "dependsOn": ["^build", "gen:api-client", "build"]
     },
     "lint": {
       "dependsOn": ["^build", "gen:api-client"]


### PR DESCRIPTION
## Summary

Adds the PR orchestrator workflow from Task 5 of the [CI/CD Pipeline design](docs/design/2026_05_24_github_ci_cd_pipeline.md): the single `.github/workflows/pr.yml` that runs on every `pull_request` to `main`, fans out to the five fast-bucket reusables with per-surface gating, and exposes a single `required` aggregator status check (the future branch-protection gate).

This is **fast-bucket only**. `docker_build` (Task 6), `e2e_test` (Task 7), and `lhci` (Task 8) are intentionally not wired here.

### Orchestrator shape

- **Trigger**: `pull_request` against `main`.
- **Concurrency**: `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`, `cancel-in-progress: true`.
- **Permissions**: `contents: read`, `actions: read`.
- **Jobs**:
  - `prepare`: single `dorny/paths-filter` step emitting 13 per-surface booleans (`rust`, `ts`, `landing`, `web`, `api`, `embedding`, `docker`, `workflows`, `terraform`, `shell`, `markdown`, `openapi`, `astro`).
  - `lint`, `type_check`, `unit_test`, `integration_test`, `security_audit`: parallel reusable dispatches via `uses: ./.github/workflows/<name>.yml`. Each `if:` and each `with:` follows the OR-with-`workflows` pattern from the design's "Dispatch gates" table — a workflow-only change re-exercises every reusable.
  - `required`: `if: always()`, runs after the five dispatches. The single `Fail if conditional jobs failed` step uses a gated-OR expression where each branch is `(<dispatch gate>) && needs.<job>.result != 'success'`, so a `skipped` reusable on a PR that doesn't touch its surfaces does not fail the aggregator.

### Design decisions worth flagging

- **`integration_test` gate is `rust || workflows`, not `rust || ts || workflows`** (design line 1027). Task 4 explicitly dropped the `ts` input from `integration_test.yml` because no TS package exposes a real `test:integration` script today; the orchestrator follows suit so dispatching to an absent input does not hard-fail. The design doc should pick this up in a follow-up edit.
- **`lint`'s `openapi` input is `openapi || workflows`**, not `openapi || rust || workflows`. The `openapi_drift` sub-job inside `lint.yml` already gates on `inputs.openapi || inputs.rust`, so passing `rust` separately (which we do) is enough.
- **`lint`'s `api` input is left at its default `false`**. The reusable declares the input but no sub-job consumes it.
- **No `env.ACT != 'true'` guards in this file**. Nothing here boots Docker, pulls images, or runs heavy tools; the ACT guards are introduced by Tasks 6 and 7 when those add the heavy dispatches.

## Test plan

- [x] `prek run --verbose` exit 0 locally.
- [x] Design fidelity verified by `code-reviewer`: aggregator branches match dispatch gates exactly; SHA pins reused from existing workflows; concurrency / permissions / runner per design.
- [ ] First real PR run: confirm boolean coercion (`${{ ... == 'true' || ... == 'true' }}` -> `type: boolean`) is interpreted correctly by the reusables.
- [ ] First real PR run: docs-only PR -> only markdown_lint + lychee run, `required` green.
- [ ] First real PR run: TS-only PR -> lint + type_check + unit_test + security_audit run, integration_test skipped, `required` green.
- [ ] Branch protection wiring is intentionally deferred to Task 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)