### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 6] docker_build wired into pr.yml

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,59 @@
+name: Docker Build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker_build:
+    name: Docker Build
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [api, embedding_service, landing, web]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # GHCR stores paths lowercase; mirror the `docker_compose_up` convention
+      # so a mixed-case fork owner cannot break the publish/pull contract.
+      - name: Export lowercase repo path
+        shell: bash
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        if: ${{ env.ACT != 'true' }}
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+
+      - name: Log in to GHCR
+        if: ${{ env.ACT != 'true' }}
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same-repo PRs publish `:pr-N` and write `:pr-N` cache; forks can only
+      # read the `:main` baseline. Empty lines in the multiline inputs are
+      # skipped by the action's CSV parser (skipEmptyLines: true).
+      - name: Build and push
+        if: ${{ env.ACT != 'true' }}
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        with:
+          context: .
+          file: apps/${{ matrix.image }}/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO }}/${{ matrix.image }}:${{ github.event.pull_request.head.sha || github.sha }}
+            ${{ github.event.pull_request.head.repo.full_name == github.repository && format('ghcr.io/{0}/{1}:pr-{2}', env.REPO, matrix.image, github.event.pull_request.number) || '' }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ env.REPO }}/${{ matrix.image }}:main
+            ${{ github.event.pull_request.head.repo.full_name == github.repository && format('type=registry,ref=ghcr.io/{0}/{1}:pr-{2}', env.REPO, matrix.image, github.event.pull_request.number) || '' }}
+          cache-to: ${{ github.event.pull_request.head.repo.full_name == github.repository && format('type=registry,ref=ghcr.io/{0}/{1}:pr-{2},mode=max', env.REPO, matrix.image, github.event.pull_request.number) || '' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,9 +142,20 @@ jobs:
       docker: ${{ needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true' }}
     secrets: inherit
 
+  # Fork PRs cannot write to GHCR; the fork guard skips this job entirely.
+  # The required aggregator exempts docker_build on forks.
+  docker_build:
+    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit ]
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.docker == 'true' ||
+       needs.prepare.outputs.workflows == 'true')
+    uses: ./.github/workflows/docker_build.yml
+    secrets: inherit
+
   required:
     name: Required
-    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit ]
+    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit, docker_build ]
     if: always()
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
@@ -165,5 +176,9 @@ jobs:
            needs.integration_test.result != 'success') ||
           ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
             needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.security_audit.result != 'success')
+           needs.security_audit.result != 'success') ||
+          (github.event.pull_request.head.repo.full_name == github.repository &&
+           (needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.docker == 'true' ||
+            needs.prepare.outputs.workflows == 'true') &&
+           needs.docker_build.result != 'success')
         run: exit 1


### PR DESCRIPTION
## Summary

Adds the Docker build reusable workflow from Task 6 of the [CI/CD Pipeline design](docs/design/2026_05_24_github_ci_cd_pipeline.md) and wires it into the PR orchestrator. Builds and publishes all four service images (`api`, `embedding_service`, `landing`, `web`) to GHCR on every relevant PR, with a `:main + :pr-N` hybrid BuildKit cache and fork-PR skip.

### `docker_build.yml`

- Reusable workflow, `permissions: contents: read`, `packages: write`.
- Single job with `matrix: [api, embedding_service, landing, web]`, `fail-fast: false`, `runs-on: ubuntu-24.04-arm`, `timeout-minutes: 20`.
- Exports `REPO=${GITHUB_REPOSITORY,,}` so GHCR paths are lowercase regardless of the fork owner's casing, mirroring `.github/actions/docker_compose_up/action.yml`.
- Tags published: `:<head-sha>` always; `:pr-N` only when `pull_request.head.repo.full_name == github.repository` (same-repo guard).
- Cache layout: `cache-from = :main + :pr-N` (the `:pr-N` line is conditioned on the fork guard); `cache-to = :pr-N,mode=max` (skipped on forks because they cannot write to GHCR).
- Heavy steps (`docker/setup-buildx-action`, `docker/login-action`, `docker/build-push-action`) are gated with `if: ${{ env.ACT != 'true' }}` so `act-pr` (Task 11) can parse the workflow without GHCR credentials.
- New SHA pins:
  - `docker/setup-buildx-action@8d2750c6 # v3.12.0`
  - `docker/login-action@c94ce9fb # v3.7.0` (matches the pin already in `docker_compose_up`)
  - `docker/build-push-action@10e90e36 # v6.19.2`

### `pr.yml`

- `docker_build` dispatch: `needs` the fast bucket (`prepare`, `lint`, `type_check`, `unit_test`, `integration_test`, `security_audit`), gated on `(rust || docker || workflows) && same-repo`.
- `required` aggregator: adds `docker_build` to `needs:`; its branch in the gated-OR carries the same fork guard so a skipped `docker_build` on a fork still leaves the aggregator green.

## Notable decisions

- **`:sha` reference**: `github.event.pull_request.head.sha || github.sha` — the PR's head commit (not the merge SHA), per the design's Architecture Overview. Falls back to `github.sha` for `workflow_dispatch` (manual smoke test on the default branch only writes `:sha`, never `:pr-N`).
- **Conditional tags / cache lines** use the `${{ <guard> && format(...) || '' }}` idiom. `docker/build-push-action`'s CSV parser ignores empty lines, so a fork run emits valid input with just the `:sha` tag and no `:pr-N`.
- **`workflows` in the dispatch gate**: matches every other dispatch in `pr.yml`. A workflow-only edit re-exercises docker_build to catch shape regressions.

## Test plan

- [x] `prek run --verbose` exit 0 locally.
- [x] `code-reviewer` agent: 0 must-fix, 1 should-fix resolved (GHCR path lowercased), 2 nits left as non-blocking.
- [ ] Same-repo Rust PR post-merge: confirm all four `:<head-sha>` tags and all four `:pr-N` tags appear on the GHCR Packages page.
- [ ] Subsequent commit on the same PR: build logs should show `Importing cache manifest from ghcr.io/.../<image>:pr-N` and warm-restore most layers.
- [ ] `:main` cache restore: validates once `tag_main_cache.yml` (Task 10) populates the baseline.
- [ ] Fork PR (open from a forked clone): `docker_build` skipped; `required` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)