### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 6.1] Grant packages: write to docker_build dispatch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,6 +150,11 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       (needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.docker == 'true' ||
        needs.prepare.outputs.workflows == 'true')
+    # Job-level permissions override the workflow-level ceiling so the called
+    # reusable can declare `packages: write` without it being capped to `none`.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/docker_build.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Hotfix for the `startup_failure` on every `pr.yml` run after Task 6 (#164) merged. GitHub Actions caps a reusable's permissions by the calling workflow's, so `docker_build.yml`'s declared `packages: write` was implicitly reduced to `packages: none` and the workflow refused to start.

Adds job-level `permissions: { contents: read, packages: write }` only on the `docker_build` dispatch in `pr.yml`, keeping every other reusable on the tighter workflow-level ceiling.

## Verification

- [x] `prek run --verbose` exit 0 locally.
- [ ] On this PR: `pr.yml` should start cleanly. The `docker_build` dispatch should fire (workflows path filter is true) and publish `:<head-sha>` + `:pr-N` tags for all four images to GHCR. The `Required` aggregator should reach a real success or failure conclusion instead of `startup_failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)