### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 7] e2e_test matrix wired into pr.yml

### DIFF
--- a/.agents/skills/implement-design/SKILL.md
+++ b/.agents/skills/implement-design/SKILL.md
@@ -14,7 +14,7 @@ description: You **must** use this when implementing the code for an approved de
     b. Implement the task using the guidelines below.
     c. Use `/code-review` skill to get feedback and iterate until it's perfect.
     d. **CRITICAL:** Ask for user's final approval. Iterate until approved.
-    e. Create a PR with title: `[{{emoji}} {{design-title}} | Part {{n}}] {{task-name}}`.
+    e. Create a PR with title: `[{{common_emoji}} {{design-title}} | Part {{n}}] {{task-name}}`.
     f. Ask user to `/compact` or `/clear` before moving to the next task.
 
 ## Guidelines

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,111 @@
+name: E2E Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  e2e_test:
+    name: E2E Test (${{ matrix.app }})
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: api
+            timeout: 30
+          - app: landing
+            timeout: 35
+          - app: web
+            timeout: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Start Docker Compose stack
+        if: env.ACT != 'true'
+        uses: ./.github/actions/docker_compose_up
+        with:
+          profile: ${{ matrix.app }}
+          tag: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # diesel `postgres` feature links against libpq at test time. Deploy
+      # workflows side-step this via `--features bundled-libs`; tests don't.
+      - name: Install libpq
+        if: matrix.app == 'api'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev
+
+      - name: Install Rust stable toolchain
+        if: matrix.app == 'api'
+        uses: ./.github/actions/rust_toolchain
+        with:
+          toolchain: stable
+
+      - name: Install Bun & dependencies
+        if: matrix.app == 'landing' || matrix.app == 'web'
+        uses: ./.github/actions/bun_install
+
+      # Playwright shells out to Node; pin Node 22 to match `type_check.yml`.
+      - name: Setup Node
+        if: matrix.app == 'landing' || matrix.app == 'web'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Install Playwright browsers
+        if: matrix.app == 'landing' || matrix.app == 'web'
+        uses: ./.github/actions/playwright_install
+        with:
+          app: ${{ matrix.app }}
+
+      # The e2e tier shares one live Postgres database; `--test-threads=1`
+      # serializes the suite to avoid cross-test contention.
+      - name: Run api e2e
+        if: matrix.app == 'api' && env.ACT != 'true'
+        run: cargo test --test e2e -- --test-threads=1
+
+      - name: Run landing e2e
+        if: matrix.app == 'landing' && env.ACT != 'true'
+        run: bun run --filter=@tokenoverflow/landing test:e2e
+
+      - name: Run web e2e
+        if: matrix.app == 'web' && env.ACT != 'true'
+        run: bun run --filter=@tokenoverflow/web test:e2e
+
+      # Without `dest:` the action streams logs to stdout for inline UI debugging.
+      - name: Stream Docker logs to stdout
+        if: failure() && env.ACT != 'true'
+        uses: step-security/gh-docker-logs@561ab0d8664f002c3eb106f4cce2799cdc4510d7  # v2.2.7
+
+      - name: Collect Docker logs to files
+        if: failure() && env.ACT != 'true'
+        uses: step-security/gh-docker-logs@561ab0d8664f002c3eb106f4cce2799cdc4510d7  # v2.2.7
+        with:
+          dest: ./docker-logs
+
+      - name: Archive Docker logs
+        if: failure() && env.ACT != 'true'
+        run: tar -czf docker-logs.tar.gz ./docker-logs
+
+      - name: Upload Docker logs
+        if: failure() && env.ACT != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: docker-logs-${{ matrix.app }}
+          path: docker-logs.tar.gz
+          retention-days: 3
+
+      - name: Upload Playwright artifacts
+        if: failure() && (matrix.app == 'landing' || matrix.app == 'web')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: playwright-${{ matrix.app }}
+          path: |
+            apps/${{ matrix.app }}/playwright-report/**
+            apps/${{ matrix.app }}/test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     outputs:
+      # Per-surface filter outputs, passed as `with:` inputs to reusables.
       rust: ${{ steps.filter.outputs.rust }}
       ts: ${{ steps.filter.outputs.ts }}
       landing: ${{ steps.filter.outputs.landing }}
@@ -31,6 +32,16 @@ jobs:
       markdown: ${{ steps.filter.outputs.markdown }}
       openapi: ${{ steps.filter.outputs.openapi }}
       astro: ${{ steps.filter.outputs.astro }}
+      # Per-job gates, consumed by dispatch `if:` and the aggregator. The
+      # fork-only gates fold the same-repo guard in so callers stay one-line.
+      same_repo: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      lint_needed: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.ts == 'true' || steps.filter.outputs.shell == 'true' || steps.filter.outputs.markdown == 'true' || steps.filter.outputs.terraform == 'true' || steps.filter.outputs.astro == 'true' || steps.filter.outputs.openapi == 'true' || steps.filter.outputs.workflows == 'true' }}
+      type_check_needed: ${{ steps.filter.outputs.ts == 'true' || steps.filter.outputs.workflows == 'true' }}
+      unit_test_needed: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.ts == 'true' || steps.filter.outputs.shell == 'true' || steps.filter.outputs.workflows == 'true' }}
+      integration_test_needed: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.workflows == 'true' }}
+      security_audit_needed: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.ts == 'true' || steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflows == 'true' }}
+      docker_build_needed: ${{ (steps.filter.outputs.rust == 'true' || steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflows == 'true') && github.event.pull_request.head.repo.full_name == github.repository }}
+      e2e_test_needed: ${{ (steps.filter.outputs.api == 'true' || steps.filter.outputs.embedding == 'true' || steps.filter.outputs.landing == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.docker == 'true' || steps.filter.outputs.openapi == 'true' || steps.filter.outputs.workflows == 'true') && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -85,11 +96,7 @@ jobs:
 
   lint:
     needs: prepare
-    if: |
-      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-      needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.markdown == 'true' ||
-      needs.prepare.outputs.terraform == 'true' || needs.prepare.outputs.astro == 'true' ||
-      needs.prepare.outputs.openapi == 'true' || needs.prepare.outputs.workflows == 'true'
+    if: needs.prepare.outputs.lint_needed == 'true'
     uses: ./.github/workflows/lint.yml
     with:
       rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
@@ -104,7 +111,7 @@ jobs:
 
   type_check:
     needs: prepare
-    if: needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true'
+    if: needs.prepare.outputs.type_check_needed == 'true'
     uses: ./.github/workflows/type_check.yml
     with:
       ts: ${{ needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true' }}
@@ -112,9 +119,7 @@ jobs:
 
   unit_test:
     needs: prepare
-    if: |
-      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-      needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true'
+    if: needs.prepare.outputs.unit_test_needed == 'true'
     uses: ./.github/workflows/unit_test.yml
     with:
       rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
@@ -124,7 +129,7 @@ jobs:
 
   integration_test:
     needs: prepare
-    if: needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true'
+    if: needs.prepare.outputs.integration_test_needed == 'true'
     uses: ./.github/workflows/integration_test.yml
     with:
       rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
@@ -132,9 +137,7 @@ jobs:
 
   security_audit:
     needs: prepare
-    if: |
-      needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-      needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true'
+    if: needs.prepare.outputs.security_audit_needed == 'true'
     uses: ./.github/workflows/security_audit.yml
     with:
       rust: ${{ needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true' }}
@@ -142,14 +145,10 @@ jobs:
       docker: ${{ needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true' }}
     secrets: inherit
 
-  # Fork PRs cannot write to GHCR; the fork guard skips this job entirely.
-  # The required aggregator exempts docker_build on forks.
+  # Same-repo only: forks cannot write to GHCR via `secrets.GITHUB_TOKEN`.
   docker_build:
     needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit ]
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.docker == 'true' ||
-       needs.prepare.outputs.workflows == 'true')
+    if: needs.prepare.outputs.docker_build_needed == 'true'
     # Job-level permissions override the workflow-level ceiling so the called
     # reusable can declare `packages: write` without it being capped to `none`.
     permissions:
@@ -158,32 +157,30 @@ jobs:
     uses: ./.github/workflows/docker_build.yml
     secrets: inherit
 
+  # Same-repo only: forks cannot pull from GHCR via `secrets.GITHUB_TOKEN`.
+  e2e_test:
+    needs: [ prepare, docker_build ]
+    if: needs.prepare.outputs.e2e_test_needed == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/e2e_test.yml
+    secrets: inherit
+
   required:
     name: Required
-    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit, docker_build ]
+    needs: [ prepare, lint, type_check, unit_test, integration_test, security_audit, docker_build, e2e_test ]
     if: always()
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Fail if conditional jobs failed
         if: |
-          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-            needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.markdown == 'true' ||
-            needs.prepare.outputs.terraform == 'true' || needs.prepare.outputs.astro == 'true' ||
-            needs.prepare.outputs.openapi == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.lint.result != 'success') ||
-          ((needs.prepare.outputs.ts == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.type_check.result != 'success') ||
-          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-            needs.prepare.outputs.shell == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.unit_test.result != 'success') ||
-          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.integration_test.result != 'success') ||
-          ((needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
-            needs.prepare.outputs.docker == 'true' || needs.prepare.outputs.workflows == 'true') &&
-           needs.security_audit.result != 'success') ||
-          (github.event.pull_request.head.repo.full_name == github.repository &&
-           (needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.docker == 'true' ||
-            needs.prepare.outputs.workflows == 'true') &&
-           needs.docker_build.result != 'success')
+          (needs.prepare.outputs.lint_needed == 'true' && needs.lint.result != 'success') ||
+          (needs.prepare.outputs.type_check_needed == 'true' && needs.type_check.result != 'success') ||
+          (needs.prepare.outputs.unit_test_needed == 'true' && needs.unit_test.result != 'success') ||
+          (needs.prepare.outputs.integration_test_needed == 'true' && needs.integration_test.result != 'success') ||
+          (needs.prepare.outputs.security_audit_needed == 'true' && needs.security_audit.result != 'success') ||
+          (needs.prepare.outputs.docker_build_needed == 'true' && needs.docker_build.result != 'success') ||
+          (needs.prepare.outputs.e2e_test_needed == 'true' && needs.e2e_test.result != 'success')
         run: exit 1


### PR DESCRIPTION
## Summary

Adds the end-to-end test reusable from Task 7 of the [CI/CD Pipeline design](docs/design/2026_05_24_github_ci_cd_pipeline.md), wires it into `pr.yml` after `docker_build`, and refactors the orchestrator's per-job gates into named `prepare` outputs so every dispatch `if:` and aggregator branch becomes a single lookup.

### `e2e_test.yml` (new)

- Reusable + `workflow_dispatch`. Permissions: `contents: read`, `packages: read`.
- Matrix `[api, landing, web]` via `include` with per-row `timeout` (30 / 35 / 25). `fail-fast: false`.
- Steps grouped by leg (no `!=` checks):
  1. api-only setup: `libpq-dev`, Rust stable toolchain.
  2. landing + web shared setup: bun_install, Node 22, playwright_install.
  3. leg-specific run: `cargo test --test e2e -- --test-threads=1` for api; `bun run --filter=<app> test:e2e` for landing/web.
- Docker log handling on failure: stream to stdout via `gh-docker-logs` (no `dest:`), collect to files (`dest: ./docker-logs`), `tar -czf` archive, `upload-artifact` with `retention-days: 3` per matrix leg.
- Playwright artifacts upload on `failure()` only — failure screenshots/traces are the useful payload.

### `pr.yml` refactor (gate centralization)

`prepare` now emits seven `<job>_needed` booleans (plus `same_repo`). Each dispatch's `if:` is a single lookup instead of a 4-7-line OR. The aggregator collapses to seven 1-line clauses (one per job).

Before — duplicated surface lists in dispatch `if:` and aggregator:
```yaml
lint:
  if: |
    needs.prepare.outputs.rust == 'true' || needs.prepare.outputs.ts == 'true' ||
    needs.prepare.outputs.shell == 'true' || ... (8 surfaces)
```
After:
```yaml
lint:
  if: needs.prepare.outputs.lint_needed == 'true'
```

Fork-only gates (`docker_build_needed`, `e2e_test_needed`) fold the same-repo guard into the boolean so callers stay one-line.

### `e2e_test` dispatch wiring

- `needs: [prepare, docker_build]` — pulls the `:<head-sha>` images that docker_build publishes.
- `if: needs.prepare.outputs.e2e_test_needed == 'true'`.
- Job-level `permissions: contents: read, packages: read` so the reusable's package-read declaration isn't capped to `none` by the workflow ceiling (same pattern as Part 6.1 for docker_build).

## Notable decisions (revisited from review)

- **Parallel matrix kept**: each leg runs on its own runner VM with its own Compose stack. No shared state. cal.com's sharding pattern doesn't transfer (they shard one suite for speed; we have three different suites).
- **`gh-docker-logs` used twice**: once without `dest:` (streams to stdout for inline UI debugging) and once with `dest:` (file capture for the artifact). Replaces the prior custom bash loop with the action's native stdout mode.
- **Playwright `webServer` in `apps/web/playwright.config.ts`** still calls `docker compose up -d --build --wait` (no profile). Verified to be a clean no-op because every Compose service is profile-gated — `docker compose config` with no profile resolves to `services: {}`. Task 12 removes the redundant block.

## Test plan

- [x] `prek run --verbose` exit 0 locally.
- [x] `code-reviewer` agent approved (0 must-fix, 1 should-fix resolved by behavior verification, nits cleared).
- [ ] First real PR run: `pr.yml` dispatches `e2e_test` after `docker_build`; all three matrix legs run; `Required` aggregator reflects their result.
- [ ] Same-repo PR touching `apps/api/src/main.rs`: e2e_test (api) pulls `:<sha>`, runs cargo e2e tests with `--test-threads=1`.
- [ ] Failure scenario: docker logs archive uploaded as `docker-logs-<app>` artifact with 3-day retention; Playwright reports uploaded as `playwright-<app>`.
- [ ] Fork PR: e2e_test job appears `skipped`; `Required` aggregator still green (`e2e_test_needed == 'false'` on forks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)