### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 9.1] Fix GHCR package paths in prune_pr_cache.yml

### DIFF
--- a/.github/workflows/prune_pr_cache.yml
+++ b/.github/workflows/prune_pr_cache.yml
@@ -20,8 +20,12 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
+    env:
+      # docker_build pushes to ghcr.io/<owner>/<repo>/<image>, so GHCR package
+      # names are `<repo>/<image>` under <owner>.
+      REPO_NAME: ${{ github.event.repository.name }}
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f  # v1.2.1
         with:
-          packages: api,embedding_service,landing,web,migrations
+          packages: ${{ env.REPO_NAME }}/api,${{ env.REPO_NAME }}/embedding_service,${{ env.REPO_NAME }}/landing,${{ env.REPO_NAME }}/web,${{ env.REPO_NAME }}/migrations
           delete-tags: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

`docker_build.yml` pushes images to `ghcr.io/<owner>/<repo>/<image>`, so GHCR registers each package as `<repo>/<image>` under `<owner>`. The freshly merged `prune_pr_cache.yml` from PR #169 was passing only the bare `<image>` name, so the action hit `/orgs/<owner>/packages/container/<image>/versions` → 404 and the `:pr-169` tags were left behind.

Build the nested path dynamically from `github.event.repository.name` so we don't hardcode the repo name.

## Test plan

- [ ] Manually delete leftover `:pr-169` tags via `gh api` (separate one-shot cleanup, since the broken workflow already ran).
- [ ] Open a probe PR; close it; confirm the workflow run logs say the action found each package (no 404) and deleted the matching `:pr-N` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)