### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 11] Trim pre-commit (drop turbo-test-e2e, simplify cargo_coverage, add act-pr)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,6 +153,12 @@ repos:
         language: system
         files: ^\.github/workflows/prune_pr_cache\.yml$
         pass_filenames: false
+      - id: act-pr
+        name: act (PR Orchestrator)
+        entry: act pull_request -W .github/workflows/pr.yml -e .github/act/event_pr.json --secret-file .act.secrets
+        language: system
+        files: ^(\.github/workflows/.*\.yml|\.github/actions/.*/action\.yml)$
+        pass_filenames: false
 
       # LINKS
       - id: lychee
@@ -199,11 +205,6 @@ repos:
       - id: turbo-test-coverage
         name: Turbo Test Coverage
         entry: bash -c 'TURBO_SCM_BASE=HEAD bun run turbo run test:coverage --affected'
-        language: system
-        pass_filenames: false
-      - id: turbo-test-e2e
-        name: Turbo Test E2E
-        entry: bash -c 'TURBO_SCM_BASE=HEAD bun run turbo run test:e2e --affected'
         language: system
         pass_filenames: false
       - id: turbo-test-lhci

--- a/scripts/src/dev_token.sh
+++ b/scripts/src/dev_token.sh
@@ -16,7 +16,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-PRIVATE_KEY_PATH="$PROJECT_ROOT/apps/api/tests/assets/auth/test_private_key.pem"
+# `TOKENOVERFLOW_PRIVATE_KEY_PATH` is a test-injection override -- lets tests
+# point at a missing path to exercise the not-found branch.
+PRIVATE_KEY_PATH="${TOKENOVERFLOW_PRIVATE_KEY_PATH:-$PROJECT_ROOT/apps/api/tests/assets/auth/test_private_key.pem}"
 CONFIG_PATH="$PROJECT_ROOT/apps/api/config/local.toml"
 
 # Defaults

--- a/scripts/src/git_hooks/cargo_coverage.sh
+++ b/scripts/src/git_hooks/cargo_coverage.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Runs coverage for all workspace members across all test tiers.
+# Runs coverage for unit and integration tiers across all workspace members.
+# E2E coverage is enforced in CI via e2e_test.yml.
 # Requires: cargo-llvm-cov (installed via setup_cargo_tools)
 # Requires: Docker running for testcontainers (integration tests)
-# Requires: Docker Compose services running for e2e tests (docker compose up -d --build api)
 
 set -euo pipefail
 
@@ -19,5 +19,5 @@ fi
 
 cargo +nightly llvm-cov \
     --workspace \
-    --lib --test unit --test integration --test e2e \
+    --lib --test unit --test integration \
     --fail-under-lines "${REQUIRED_COVERAGE}"

--- a/scripts/tests/test_dev_token.sh
+++ b/scripts/tests/test_dev_token.sh
@@ -222,12 +222,9 @@ function test_default_sub_is_system() {
 
 function test_missing_private_key_returns_error() {
   local output
-  # Override PRIVATE_KEY_PATH by temporarily renaming the key
-  local key="apps/api/tests/assets/auth/test_private_key.pem"
-  mv "$key" "${key}.bak"
-  output=$($SCRIPT 2>&1)
-  local exit_code=$?
-  mv "${key}.bak" "$key"
-  assert_equals "1" "$exit_code"
+  # Point at a non-existent path via env override. Avoids renaming the real
+  # key, which would touch its ctime and confuse git's stat cache.
+  output=$(TOKENOVERFLOW_PRIVATE_KEY_PATH=/nonexistent/test_private_key.pem $SCRIPT 2>&1)
+  assert_exit_code "1"
   assert_contains "test private key not found" "$output"
 }


### PR DESCRIPTION
## Summary

Implements Task 11 of the [GitHub CI/CD Pipeline design doc](../blob/main/docs/design/2026_05_24_github_ci_cd_pipeline.md#task-11-trim-pre-commit).

- Drops the local `turbo-test-e2e` hook from `.pre-commit-config.yaml`; CI's `e2e_test.yml` now owns e2e execution.
- Simplifies `scripts/src/git_hooks/cargo_coverage.sh` by removing `--test e2e`; coverage threshold (`--fail-under-lines 95`) is preserved.
- Adds an `act-pr` hook scoped to `.github/workflows/**` and `.github/actions/**` so workflow edits get a local parse check.
- Refactors `test_missing_private_key_returns_error` in `scripts/tests/test_dev_token.sh` to use a new `TOKENOVERFLOW_PRIVATE_KEY_PATH` env override on `dev_token.sh`, replacing a `mv` of the real test key that tripped prek 0.4.2's "files were modified" false positive (per CLAUDE.md's fix-unrelated-hook rule).

## Test plan

- [x] `prek run --verbose` exits 0 locally.
- [x] `turbo-test-e2e` absent from the prek summary (verified by grep).
- [x] `act (PR Orchestrator)` (a.k.a. `act-pr`) registered in the prek summary.
- [x] `bashunit` reports `101 passed, 101 total`.

### Evidence

From `prek run --verbose` (exit 0):

```
Bash Unit Tests..........................................................Passed
- hook id: bashunit
  bashunit - 0.36.0 | Tests: 101
  ...
  Tests:      101 passed, 101 total

act (PR Orchestrator)................................(no files to check)Skipped
```

`turbo-test-e2e` does not appear in the summary (`grep -c 'turbo-test-e2e' /tmp/prek.log` -> `0`).