### PR TITLE
[⚙️ Github CI/CD Pipeline | Part 13] dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,7 @@ updates:
               patterns: ["*"]
     - package-ecosystem: github-actions
       directories:
-          - /.github/actions/bun_install
-          - /.github/actions/rust_toolchain
-          - /.github/actions/docker_compose_up
-          - /.github/actions/playwright_install
+          - /.github/actions/*
       schedule: { interval: weekly }
       groups:
           composite-action-internals:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule: { interval: weekly }
+      groups:
+          workflow-actions:
+              patterns: ["*"]
+    - package-ecosystem: github-actions
+      directories:
+          - /.github/actions/bun_install
+          - /.github/actions/rust_toolchain
+          - /.github/actions/docker_compose_up
+          - /.github/actions/playwright_install
+      schedule: { interval: weekly }
+      groups:
+          composite-action-internals:
+              patterns: ["*"]


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to keep pinned GitHub Actions SHAs current.
- Two `updates:` entries split workflow actions from composite-action internals so each produces its own weekly PR.
- Grouping (`workflow-actions` and `composite-action-internals`) keeps SHA bumps consolidated rather than one PR per action.

Implements Task 13 of the GitHub CI/CD Pipeline design doc.

## Test plan

- [ ] Dependabot accepts the config (Insights > Dependency graph > Dependabot shows both ecosystems active).
- [ ] First scheduled run produces at most two PRs (one per group) instead of one per action.
- [ ] The composite-actions PR includes bumps from all four `directories:` entries when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)