### PR TITLE
Fix pr.yml path filters: negation patterns fire as positive matches

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,8 +53,6 @@ jobs:
           # like '!**/*.md' fires as a positive match on every non-`.md` file.
           # Embed the negation as an extglob suffix on the parent path instead
           # so it constrains that one pattern's filename match.
-          # `integrations/**` is intentionally broad: api Dockerfile COPYs
-          # `integrations/claude/instructions.md` into the build context.
           filters: |
             rust:
               - 'apps/api/**/!(*.md|*.mdx)'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,54 +48,45 @@ jobs:
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         with:
+          # dorny/paths-filter evaluates each list entry as an independent
+          # picomatch pattern and OR's the results, so a standalone negation
+          # like '!**/*.md' fires as a positive match on every non-`.md` file.
+          # Embed the negation as an extglob suffix on the parent path instead
+          # so it constrains that one pattern's filename match.
+          # `integrations/**` is intentionally broad: api Dockerfile COPYs
+          # `integrations/claude/instructions.md` into the build context.
           filters: |
             rust:
-              - 'apps/api/**'
-              - 'apps/embedding_service/**'
-              - 'apps/so_tag_sync/**'
+              - 'apps/api/**/!(*.md|*.mdx)'
+              - 'apps/embedding_service/**/!(*.md|*.mdx)'
+              - 'apps/so_tag_sync/**/!(*.md|*.mdx)'
               - 'integrations/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - '!**/*.md'
-              - '!**/*.mdx'
             ts:
-              - 'apps/web/**'
-              - 'apps/landing/**'
-              - 'packages/**'
+              - 'apps/web/**/!(*.md|*.mdx)'
+              - 'apps/landing/**/!(*.md|*.mdx)'
+              - 'packages/**/!(*.md|*.mdx)'
               - 'apps/api/openapi.json'
               - 'package.json'
               - 'bun.lock'
               - 'bunfig.toml'
               - 'turbo.json'
-              - '!**/*.md'
-              - '!**/*.mdx'
             landing:
-              - 'apps/landing/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - 'apps/landing/**/!(*.md|*.mdx)'
             web:
-              - 'apps/web/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - 'apps/web/**/!(*.md|*.mdx)'
             api:
-              - 'apps/api/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - 'apps/api/**/!(*.md|*.mdx)'
             embedding:
-              - 'apps/embedding_service/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - 'apps/embedding_service/**/!(*.md|*.mdx)'
             docker:
               - 'docker-compose.yml'
               - 'apps/*/Dockerfile'
-              - 'infra/docker/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - 'infra/docker/**/!(*.md|*.mdx)'
             workflows:
-              - '.github/workflows/**'
-              - '.github/actions/**'
-              - '!**/*.md'
-              - '!**/*.mdx'
+              - '.github/workflows/**/!(*.md|*.mdx)'
+              - '.github/actions/**/!(*.md|*.mdx)'
             terraform:
               - 'terraform/**'
               - '**/*.tf'


### PR DESCRIPTION
## Summary

- `dorny/paths-filter` evaluates each YAML list entry as an independent picomatch pattern and OR's the results (`predicate-quantifier` defaults to `'some'`), so a bare `'!**/*.md'` is parsed by picomatch as "match any file that is not a `.md` file" and fires positive on every non-markdown diff.
- Real-world impact: PR #174 changed only `.github/dependabot.yml` yet `prepare` reported `rust/ts/landing/web/api/embedding/docker/workflows` all `true`, cascading into `unit_test`, `integration_test`, `security_audit`, `lhci`, `docker_build`, `e2e_test`, `type_check`, and `lint`.
- Fix: drop the standalone negation entries and embed the doc exclusion as a picomatch extglob suffix on each parent path (e.g. `apps/api/**/!(*.md|*.mdx)`). `integrations/**` intentionally stays broad because the api `Dockerfile` COPYs `integrations/claude/instructions.md` into the build context.

## Root cause

Verified by reading `src/filter.ts` at the pinned SHA `de90cc6fb38fc0963ad72b210f1f284cd68cea36` (v3.0.2). The action parses every YAML list item independently via `picomatch(item, MatchOptions)` and stores them as separate `FilterRuleItem`s. The `isMatch` method runs `patterns.some(aPredicate)` (default quantifier), so the filter is ORed across patterns. picomatch's leading-`!` syntax means "match files that do not match the rest of the pattern," not "subtract from the previous results." Confirmed with `picomatch@4.0.4`: `picomatch('!**/*.md')('.github/dependabot.yml')` returns `true`.

The narrower form `'!apps/api/**/*.md'` is also broken under `'some'` semantics: it still matches any file outside `apps/api/**/*.md`, including `.github/dependabot.yml`. Standalone negation only works under `predicate-quantifier: every`, which would in turn break the OR'd inclusion patterns this filter relies on. Extglob `!(*.md|*.mdx)` works because it is part of a single positive pattern and constrains that one matcher's filename match.

## Verified scenarios

Run against the final filter block (replicating dorny/paths-filter's logic via `picomatch` with `dot: true`):

| PR changes only | filters that fire | `*_needed` gates that fire |
|---|---|---|
| `.github/dependabot.yml` | none | none |
| `README.md` | markdown | lint |
| `apps/api/tests/e2e/README.md` | markdown | lint |
| `apps/api/src/main.rs` | rust, api | lint, unit_test, integration_test, security_audit, docker_build, e2e_test |
| `apps/web/src/page.tsx` | ts, web | lint, type_check, unit_test, security_audit, docker_build, e2e_test |
| `apps/landing/src/index.astro` | ts, landing, astro | lint, type_check, unit_test, security_audit, lhci, docker_build, e2e_test |
| `apps/api/openapi.json` | rust, ts, api, openapi | lint, type_check, unit_test, integration_test, security_audit, docker_build, e2e_test |
| `.github/workflows/foo.yml` | workflows | lint, type_check, unit_test, integration_test, security_audit, lhci |
| `docker-compose.yml` | docker | security_audit, docker_build, e2e_test |
| `infra/docker/diesel/Dockerfile` | docker | security_audit, docker_build, e2e_test |
| `apps/api/migrations/2024_xx.sql` | rust, api | lint, unit_test, integration_test, security_audit, docker_build, e2e_test |
| `Cargo.lock` | rust | lint, unit_test, integration_test, security_audit, docker_build, e2e_test |
| `bun.lock` | ts | lint, type_check, unit_test, security_audit, docker_build, e2e_test |
| `integrations/claude/instructions.md` | rust, markdown | lint, unit_test, integration_test, security_audit, docker_build, e2e_test |

Two notes on rows that diverge from the spec's expectations:

- `README.md` / `apps/api/tests/e2e/README.md`: `markdown` is part of `lint_needed`, so `lint` fires. That preserves the existing intent (markdownlint + lychee run on doc changes). The bug being fixed here is the language CI legs firing on docs-only PRs; those are now silent.
- `.github/workflows/foo.yml`: `workflows` is wired through every gate in `pr.yml`'s `*_needed` formulas. Per the task constraint "don't change CI behavior beyond fixing the filter logic," that cascade is left alone. If you want workflow YAML edits to skip language CI (since `actionlint` runs in `prek`), it is a separate intent change to those gate formulas, not a filter bug.

## Test plan

- [x] Hypothesis verified against `dorny/paths-filter@v3.0.2` source.
- [x] Behavior reproduced with `picomatch@4.0.4` standalone.
- [x] Final filter block validated against every scenario above.
- [x] `prek run --verbose` exits 0 (actionlint included).
- [ ] Open this PR and confirm `Prepare` reports only `workflows = true` on this diff (this PR touches only `.github/workflows/pr.yml`), and that the downstream cascade matches the `.github/workflows/foo.yml` row above.