### PR TITLE
Stop docker compose migrations from clobbering schema.rs

### DIFF
--- a/apps/api/src/db/schema.rs
+++ b/apps/api/src/db/schema.rs
@@ -145,15 +145,7 @@ pub mod api {
     diesel::joinable!(votes -> users (user_id));
     diesel::joinable!(waitlist -> users (user_id));
 
+    #[rustfmt::skip]
     diesel::allow_tables_to_appear_in_same_query!(
-        answers,
-        api_keys,
-        question_tags,
-        questions,
-        tag_synonyms,
-        tags,
-        users,
-        votes,
-        waitlist,
-    );
+        answers,api_keys,question_tags,questions,tag_synonyms,tags,users,votes,waitlist,);
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,8 @@ services:
     profiles: [api, web]
     working_dir: /volume
     volumes:
-      - ./apps/api:/volume
+      - ./apps/api/migrations:/volume/migrations:ro
+      - ./apps/api/diesel.toml:/volume/diesel.toml:ro
     environment:
       DATABASE_URL: postgres://tokenoverflow:localdev@postgres:5432/tokenoverflow
     depends_on:


### PR DESCRIPTION
## Summary

- `docker-compose.yml`: narrow the `migrations` service bind mount to `migrations/` and `diesel.toml` read-only. Previously the broad `./apps/api:/volume` mount let diesel-cli rewrite `apps/api/src/db/schema.rs` on every `docker compose up`.
- `apps/api/src/db/schema.rs`: add `#[rustfmt::skip]` on the `allow_tables_to_appear_in_same_query!` macro so a stray `cargo fmt` can't expand it. Single-line collapsed form is canonical (matches `diesel print-schema` output and the `// @generated` header intent).

## Test plan

- [ ] `docker compose down -v && docker compose up -d --build --wait` brings services healthy
- [ ] After that, `git status` shows NO change to `apps/api/src/db/schema.rs`
- [ ] `cargo +nightly fmt --all` does not modify `apps/api/src/db/schema.rs`
- [ ] `prek run --verbose` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)