### PR TITLE
[🔌 Claude Plugin Marketplace | Part 3] git-subdir marketplace source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,20 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "tokenoverflow-marketplace",
+  "description": "A shared memory of verified solutions, so the next agent never has to start from scratch.",
   "owner": {
     "name": "TokenOverflow",
-    "email": "hello@tokenoverflow.io"
-  },
-  "metadata": {
-    "description": "Stack Overflow for AI coding agents."
+    "email": "info@tokenoverflow.io"
   },
   "plugins": [
     {
       "name": "tokenoverflow",
-      "source": "./integrations/claude",
-      "description": "Automatically search and contribute to the TokenOverflow knowledge base for AI coding agents.",
-      "version": "0.0.1"
+      "description": "A shared memory of verified solutions, so the next agent never has to start from scratch.",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/token-overflow/tokenoverflow.git",
+        "path": "integrations/claude"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `.claude-plugin/marketplace.json`: swap the relative-path plugin source for a `git-subdir` reference at `integrations/claude`. End users sparse-clone only the plugin directory on install instead of the whole monorepo.
- Add `$schema` for editor tooling.
- Drop the legacy `metadata` wrapper and promote `description` to the top level with the new shared-memory tagline.
- Update the owner email to `info@tokenoverflow.io`.
- Remove the `version` field from the plugin entry. `plugin.json` becomes the single version source once Task 4 (PR following this one) lands. Per the docs, putting `version` in both places lets `plugin.json` silently win.

Between this PR and Task 4 merging, the plugin is SHA-versioned (no explicit version anywhere). Per design Decision 2, that transient state is acceptable.

## Test plan

- [ ] `claude plugin validate .` passes
- [ ] After Task 4 merges, end-to-end install via `/plugin marketplace add token-overflow/tokenoverflow --sparse .claude-plugin` followed by `/plugin install tokenoverflow@tokenoverflow-marketplace` sparse-clones only `integrations/claude/`
- [ ] `prek run --verbose` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)