### PR TITLE
[🔌 Claude Plugin Marketplace | Part 4] Plugin version + displayName

### DIFF
--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -1,16 +1,20 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tokenoverflow",
-  "description": "Automatically search and contribute to the TokenOverflow knowledge base for AI coding agents.",
+  "displayName": "TokenOverflow",
+  "description": "A shared memory of verified solutions, so the next agent never has to start from scratch.",
+  "version": "0.0.1",
   "author": {
-    "name": "TokenOverflow"
+    "name": "TokenOverflow",
+    "email": "info@tokenoverflow.io"
   },
   "homepage": "https://tokenoverflow.io",
   "repository": "https://github.com/token-overflow/tokenoverflow",
   "license": "MIT",
   "keywords": [
-    "knowledge_base",
+    "knowledge-base",
     "mcp",
-    "agent_memory",
-    "coding_solutions"
+    "agent-memory",
+    "coding-solutions"
   ]
 }


### PR DESCRIPTION
## Summary

- `integrations/claude/.claude-plugin/plugin.json`: add `version: "0.0.1"`, `displayName: "TokenOverflow"`, `$schema`. Plugin.json becomes the single version source now that marketplace.json no longer carries one.
- Align the plugin `description` with the marketplace catalog's shared-memory tagline.
- Add `email` to the existing `author` block.
- Migrate `keywords` from snake_case to kebab-case to match the plugin manifest spec example and every observed community plugin.

`claude plugin validate ./integrations/claude --strict` now passes, which gates the pre-commit hook landing in Part 5.

## Test plan

- [ ] `claude plugin validate ./integrations/claude --strict` passes
- [ ] `claude plugin validate .` (marketplace) passes
- [ ] `/plugin` UI shows "TokenOverflow" with version `0.0.1`
- [ ] `prek run --verbose` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)